### PR TITLE
Fix examples documentation

### DIFF
--- a/examples/02-controls/05-math-ops.py
+++ b/examples/02-controls/05-math-ops.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 """
 05-math-ops.py - Audio objects and arithmetic expresssions.
 
@@ -16,6 +15,7 @@ PyoObject can also be used in expression with the exponent (**),
 modulo (%) and unary negative (-) operators.
 
 """
+from __future__ import print_function
 from pyo import *
 
 s = Server().boot()

--- a/examples/05-envelopes/01-data-signal-conversion.py
+++ b/examples/05-envelopes/01-data-signal-conversion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 """
 01-data-signal-conversion.py - Conversion from number to audio stream.
 
@@ -12,6 +11,7 @@ The Sig object converts a number to an audio stream.
 The PyoObject.get() method extracts a float from an audio stream.
 
 """
+from __future__ import print_function
 from pyo import *
 
 s = Server().boot()


### PR DESCRIPTION
Sphinx does not generate proper link for an example in the
documentation if the file begins with an import.