### PR TITLE
Add missing import of random module

### DIFF
--- a/examples/sequencing/01_starttime_duration.py
+++ b/examples/sequencing/01_starttime_duration.py
@@ -6,6 +6,7 @@ methods to sequence events over time.
 
 """
 from pyo import *
+import random
 
 s = Server(duplex=0).boot()
 


### PR DESCRIPTION
This pull request fixes the missing import of the random module in example `examples/sequencing/01_starttime_duration.py`.