### PR TITLE
Make _linux_wheel_symlinks.py work on Fedora

### DIFF
--- a/pyo/_linux_wheel_fix_symlinks.py
+++ b/pyo/_linux_wheel_fix_symlinks.py
@@ -63,11 +63,11 @@ if need_symlinks:
         for root, dirs, files in os.walk(path):
             for f in files:
                 if libasound:
-                    if f == "libasound.so":
+                    if not libasoundfound and "libasound.so" in f:
                         libasoundpath = os.path.join(root, f)
                         libasoundfound = True
                 if libjack:
-                    if f == "libjack.so":
+                    if not libjackfound and "libjack.so" in f:
                         libjackpath = os.path.join(root, f)
                         libjackfound = True
                 if withlibasound == libasoundfound and withlibjack == libjackfound:


### PR DESCRIPTION
Fedora and possibly other distros do not provide `.so$` symbolic links. 
As an example, symlinks on Fedora 30 are `libjack.so.0`, `libasound.so.2`.
