### PR TITLE
Fixed small typos in Spectrum documentation

### DIFF
--- a/pyo/lib/analysis.py
+++ b/pyo/lib/analysis.py
@@ -1016,7 +1016,7 @@ class Spectrum(PyoObject):
         """
         Sets the lower frequency, as multiplier of sr, returned by the analysis.
 
-        Returns the real low frequency en Hz.
+        Returns the real low frequency in Hz.
 
         :Args:
 
@@ -1034,7 +1034,7 @@ class Spectrum(PyoObject):
         """
         Sets the higher frequency, as multiplier of sr, returned by the analysis.
 
-        Returns the real high frequency en Hz.
+        Returns the real high frequency in Hz.
 
         :Args:
 


### PR DESCRIPTION
Hello Olivier,
I just fixed two doc string typos for the Spectrum object.
Thank you for your work!