### PR TITLE
Fix compilation for Python 3.9

### DIFF
--- a/src/objects/bandsplitmodule.c
+++ b/src/objects/bandsplitmodule.c
@@ -1769,7 +1769,7 @@ MultiBandMain_setFrequencies(MultiBandMain* self, PyObject *arg)
 {
     int i, bounds = self->nbands - 1;
 
-    if PyList_Check(arg)
+    if (PyList_Check(arg))
     {
         if (PyList_Size(arg) == bounds)
         {


### PR DESCRIPTION
I was working on adding support for Python 3.9 wheels in https://github.com/belangeo/pyo-linux-wheels/pull/1, when I encountered the following error: https://travis-ci.com/github/belangeo/pyo-linux-wheels/jobs/396353858#L5564. Parenthesising the if statement fixed it.