### PR TITLE
docs: fix simple typo, exibit -> exhibit

### DIFF
--- a/pyo/lib/randoms.py
+++ b/pyo/lib/randoms.py
@@ -1418,7 +1418,7 @@ class LogiMap(PyoObject):
     growth curve) is a model of population growth first published by Pierre
     Verhulst (1845, 1847). The logistic map is a discrete quadratic recurrence
     equation derived from the logistic equation that can be effectively used
-    as a number generator that exibit chaotic behavior. This object uses the
+    as a number generator that exhibit chaotic behavior. This object uses the
     following equation:
 
         x[n] = (r + 3) * x[n-1] * (1.0 - x[n-1])


### PR DESCRIPTION
There is a small typo in pyo/lib/randoms.py.

Should read `exhibit` rather than `exibit`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md