### PR TITLE
Raise exception on error

### DIFF
--- a/pyo/lib/_core.py
+++ b/pyo/lib/_core.py
@@ -175,7 +175,10 @@ def sndinfo(path, print=False):
 
     """
     path = stringencode(path)
-    return p_sndinfo(path, print)
+    info = p_sndinfo(path, print)
+    if info is None:
+        raise PyoError("Could not get file info")
+    return info
 
 
 def savefile(samples, path, sr=44100, channels=1, fileformat=0, sampletype=0, quality=0.4):

--- a/pyo/lib/_core.py
+++ b/pyo/lib/_core.py
@@ -95,7 +95,7 @@ FUNCTIONS_INIT_LINES = {
     "pm_get_input_devices": "pm_get_input_devices()",
     "pm_list_devices": "pm_list_devices()",
     "pm_count_devices": "pm_count_devices()",
-    "sndinfo": "sndinfo(path, print=False)",
+    "sndinfo": "sndinfo(path, print=False, raise_on_failure=False)",
     "savefile": "savefile(samples, path, sr=44100, channels=1, fileformat=0, sampletype=0, quality=0.4)",
     "savefileFromTable": "savefileFromTable(table, path, fileformat=0, sampletype=0, quality=0.4)",
     "upsamp": "upsamp(path, outfile, up=4, order=128)",
@@ -148,7 +148,7 @@ def stringencode(st):
     return st
 
 
-def sndinfo(path, print=False):
+def sndinfo(path, print=False, raise_on_failure=False):
     """
     Retrieve informations about a soundfile.
 
@@ -165,6 +165,9 @@ def sndinfo(path, print=False):
         print: boolean, optional
             If True, sndinfo will print sound infos to the console.
             Defaults to False.
+        raise_on_failure: boolean, optional
+            If True, sndinfo will raise an exception when failing to get file info.
+            Defaults to False.
 
     >>> path = SNDS_PATH + '/transparent.aif'
     >>> print(path)
@@ -176,8 +179,8 @@ def sndinfo(path, print=False):
     """
     path = stringencode(path)
     info = p_sndinfo(path, print)
-    if info is None:
-        raise PyoError("Could not get file info")
+    if info is None and raise_on_failure:
+        raise PyoError("Could not get file ({:}) info".format(path))
     return info
 
 

--- a/pyo/lib/fourier.py
+++ b/pyo/lib/fourier.py
@@ -1315,7 +1315,7 @@ class CvlVerb(PyoObject):
         impulse, lmax2 = convertArgsToLists(impulse)
         self._base_objs = []
         for file in impulse:
-            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(file)
+            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(file, raise_on_failure=True)
             lmax3 = max(lmax, _snd_chnls)
             self._base_objs.extend(
                 [

--- a/pyo/lib/players.py
+++ b/pyo/lib/players.py
@@ -110,7 +110,7 @@ class SfPlayer(PyoObject):
         self._base_objs = []
         _trig_objs_tmp = []
         for i in range(lmax):
-            _snd_size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path[0])
+            _snd_size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path[0], raise_on_failure=True)
             self._base_players.append(
                 SfPlayer_base(
                     stringencode(wrap(path, i)), wrap(speed, i), wrap(loop, i), wrap(offset, i), wrap(interp, i)
@@ -137,15 +137,15 @@ class SfPlayer(PyoObject):
         """
         pyoArgsAssert(self, "s", path)
         if type(self._path) == list:
-            curNchnls = sndinfo(self._path[0])[3]
+            curNchnls = sndinfo(self._path[0], raise_on_failure=True)[3]
         else:
-            curNchnls = sndinfo(self._path)[3]
+            curNchnls = sndinfo(self._path, raise_on_failure=True)[3]
         if type(path) == list:
             p = path[0]
         else:
             p = path
         try:
-            _snd_size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p)
+            _snd_size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p, raise_on_failure=True)
         except:
             return
         if _snd_chnls != curNchnls:
@@ -353,7 +353,7 @@ class SfMarkerShuffler(PyoObject):
         path, speed, interp, mul, add, lmax = convertArgsToLists(path, speed, interp, mul, add)
         self._base_players = []
         self._base_objs = []
-        self._snd_size, self._dur, self._snd_sr, self._snd_chnls, _format, _type = sndinfo(path[0])
+        self._snd_size, self._dur, self._snd_sr, self._snd_chnls, _format, _type = sndinfo(path[0], raise_on_failure=True)
         for i in range(lmax):
             try:
                 sf = aifc.open(wrap(path, i))  # Do we need stringencode() here?
@@ -549,7 +549,7 @@ class SfMarkerLooper(PyoObject):
         path, speed, mark, interp, mul, add, lmax = convertArgsToLists(path, speed, mark, interp, mul, add)
         self._base_players = []
         self._base_objs = []
-        self._snd_size, self._dur, self._snd_sr, self._snd_chnls, _format, _type = sndinfo(path[0])
+        self._snd_size, self._dur, self._snd_sr, self._snd_chnls, _format, _type = sndinfo(path[0], raise_on_failure=True)
         for i in range(lmax):
             try:
                 sf = aifc.open(wrap(path, i))

--- a/pyo/lib/tables.py
+++ b/pyo/lib/tables.py
@@ -1643,7 +1643,7 @@ class SndTable(PyoTableObject):
             self._base_objs = [SndTable_base("", 0, 0) for i in range(initchnls)]
         else:
             for p in path:
-                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p)
+                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p, raise_on_failure=True)
                 if chnl is None:
                     if stop is None:
                         self._base_objs.extend([SndTable_base(stringencode(p), i, start) for i in range(_snd_chnls)])
@@ -1689,7 +1689,7 @@ class SndTable(PyoTableObject):
             path, lmax = convertArgsToLists(path)
             for i, obj in enumerate(self._base_objs):
                 p = path[i % lmax]
-                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p)
+                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p, raise_on_failure=True)
                 self._size.append(_size)
                 self._dur.append(_dur)
                 if stop is None:
@@ -1697,7 +1697,7 @@ class SndTable(PyoTableObject):
                 else:
                     obj.setSound(stringencode(p), 0, start, stop)
         else:
-            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path)
+            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path, raise_on_failure=True)
             self._size = _size
             self._dur = _dur
             if stop is None:
@@ -1739,7 +1739,7 @@ class SndTable(PyoTableObject):
             path, lmax = convertArgsToLists(path)
             for i, obj in enumerate(self._base_objs):
                 p = path[i % lmax]
-                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p)
+                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p, raise_on_failure=True)
                 self._size.append(_size)
                 self._dur.append(_dur)
                 if stop is None:
@@ -1747,7 +1747,7 @@ class SndTable(PyoTableObject):
                 else:
                     obj.append(stringencode(p), crossfade, 0, start, stop)
         else:
-            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path)
+            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path, raise_on_failure=True)
             self._size = _size
             self._dur = _dur
             if stop is None:
@@ -1797,7 +1797,7 @@ class SndTable(PyoTableObject):
             path, lmax = convertArgsToLists(path)
             for i, obj in enumerate(self._base_objs):
                 p = path[i % lmax]
-                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p)
+                _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(p, raise_on_failure=True)
                 self._size.append(_size)
                 self._dur.append(_dur)
                 if stop is None:
@@ -1805,7 +1805,7 @@ class SndTable(PyoTableObject):
                 else:
                     obj.insert(stringencode(p), pos, crossfade, 0, start, stop)
         else:
-            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path)
+            _size, _dur, _snd_sr, _snd_chnls, _format, _type = sndinfo(path, raise_on_failure=True)
             self._size = _size
             self._dur = _dur
             if stop is None:


### PR DESCRIPTION
*sndinfo* returns *None* when it can't get file info (for whatever reason). That yields an confusing error message like in [[SO]: Can't reproduce audio file using python pyo library](https://stackoverflow.com/q/72511881/4788546).

I thought of other possible fixes, but this seemed the best (or simplest):

- Return a tuple containing some invalid data (-1 for numbers and empty stings) - but that would only postpone the error (till when the data will be used)
- Fix (do the *None* test) all places where this function is used and assume it returns a tuple

After reading the comment did some changes:
- Exception raising is optional and disabled by default
- Enabled it on files from *lib*. Functionally it makes no difference as an exception would have been raised anyway

**Note**: There are other places that could be changed (tests, examples) but I don't consider them critical.
