### PR TITLE
Fix for #241: Python 3.10 breaks SfPlayer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ compile_externals = False
 win_arch = platform.architecture()[0]
 
 macros = []
+if sys.version_info[:2] >= (3, 10):  # https://bugs.python.org/issue40943
+    macros.append(("PY_SSIZE_T_CLEAN", None))
+
 extension_names = ["pyo._pyo"]
 extra_macros_per_extension = [[]]
 packages = [


### PR DESCRIPTION
Attempt to fix #241 (also reported: [\[SO\]: PyAudio.write SystemError: PY\_SSIZE\_T\_CLEAN macro must be defined for '#' formats](https://stackoverflow.com/q/70344884/4788546)).

Defines *PY\_SSIZE\_T\_CLEAN* in *setup.py*.

Some (new) compiler warnings are generated, as the macro is already defined (manually) in some *.c* files.  Those definitions should be removed (not sure if they previously served a purpose), considering that *setup.py* is the official build method, but anyway that could be the subject of another (cleanup) *PR*.

**Tests**

- [\[SO\]: Can't install pyo using pip (@CristiFati's answer)](https://stackoverflow.com/a/73512700/4788546) (*Win* only - #245)


**Note: Currently, the behavior has only been suppressed meaning that it will work just like in older *Python* versions, but it will not properly handle the case it was introduced for (containers having more than 2 *Gi* elements).**