### PR TITLE
Fix for #241: Python 3.10 breaks SfPlayer

### DIFF
--- a/src/engine/midilistenermodule.c
+++ b/src/engine/midilistenermodule.c
@@ -678,7 +678,8 @@ PyObject *
 MidiDispatcher_sendx(MidiDispatcher *self, PyObject *args)
 {
     unsigned char *msg;
-    int i, size, device;
+    int i, device;
+    Py_ssize_t size;
     long curtime;
     PmTimestamp timestamp;
 

--- a/src/engine/midilistenermodule.c
+++ b/src/engine/midilistenermodule.c
@@ -18,6 +18,8 @@
  * License along with pyo.  If not, see <http://www.gnu.org/licenses/>.   *
  *************************************************************************/
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include "structmember.h"
 #include <math.h>

--- a/src/engine/servermodule.c
+++ b/src/engine/servermodule.c
@@ -2311,7 +2311,7 @@ PyObject *
 Server_sysexout(Server *self, PyObject *args)
 {
     unsigned char *msg;
-    int size;
+    Py_ssize_t size;
     PyoMidiTimestamp timestamp;
 
     if (! PyArg_ParseTuple(args, "s#l", &msg, &size, &timestamp))


### PR DESCRIPTION
This is a continuation of [\[GitHub\]: belangeo/pyo - Fixed PY\_SSIZE\_T\_CLEAN macro must be defined for '#' formats](https://github.com/belangeo/pyo/commit/7aeb2e881bb841b44b4b7f8aa5d5f3707198b9ac)

Replaces #247, as that one is just a workaround (*gainarie*).
But everything in there still applies (testing and stuff), so I'm not going to duplicate that info here, but it worth going through it (and referenced *URL*s).

Linking #241.

**Note**: Used [\[GitHub\]: CristiFati/code\_checker - Code checker](https://github.com/CristiFati/code_checker) to identify places needing attention in the code.
