### PR TITLE
Fix Undefined Behavior (Win 032bit)

### DIFF
--- a/src/engine/pyomodule.c
+++ b/src/engine/pyomodule.c
@@ -420,7 +420,7 @@ p_sndinfo(PyObject *self, PyObject *args, PyObject *kwds)
                           path, (int)info.frames, ((float)info.frames / info.samplerate), (float)info.samplerate, (int)info.channels,
                           fileformat, sampletype);
 
-    return Py_BuildValue("lffiss", info.frames, (float)info.frames / info.samplerate, (float)info.samplerate, info.channels, fileformat, sampletype);
+    return Py_BuildValue("Lffiss", info.frames, (float)info.frames / info.samplerate, (float)info.samplerate, info.channels, fileformat, sampletype);
 }
 
 static PyObject *


### PR DESCRIPTION
*SF\_INFO.frames* is typed as *sf\_count\_t*, which is a ***\_\_int64*** *typedef* (*sndfile.h*).

*Py\_BuildValue*'s `l` flag converts a *C* ***long int***.

This yields ***U**ndefined **B**ehavior* (check [\[SO\]: \_csv.Error: field larger than field limit (131072) (@CristiFati's answer)](https://stackoverflow.com/a/54517228/4788546) for more details) on *032bit* *Nix*es and *Win* (it works on others purely coincidental).

Crashes *Python* *pc032* (only) on *Win*.  [\[SO\]: Can't install pyo using pip (@CristiFati's answer)](https://stackoverflow.com/a/73512700/4788546) (the *SfPlayer* line at the end).

Linking #248.
