### PR TITLE
PEP 517/518 compliance: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Added a minimal `pyproject.toml`, so that e.g. `pip wheel --use-pep517` and `poetry add pyo` can be used.

* [PEP 517](https://peps.python.org/pep-0517/)
* [PEP 518](https://peps.python.org/pep-0518/)