### PR TITLE
replace deprecated mock by unittest.mock

### DIFF
--- a/tests/pytests/test_baseObjects.py
+++ b/tests/pytests/test_baseObjects.py
@@ -1,7 +1,9 @@
 import os
+from unittest import mock
+
 import pytest
-import mock
 import numpy
+
 from utilities import *
 from pyo import *
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.