### PR TITLE
Escape backslashes in docstrings

### DIFF
--- a/pyo/examples/x22-events/08-function-calls.py
+++ b/pyo/examples/x22-events/08-function-calls.py
@@ -5,7 +5,7 @@
 
     EventCall(function, *args, occurrences=inf, stopEventsWhenDone=True)
 
-EventCall calls a function, with any number of arguments (\*args) and uses
+EventCall calls a function, with any number of arguments (\\*args) and uses
 its return value for the given parameter. The example below use a function
 from the random module, *randrange*, with arguments and a user-defined
 function, without argument, to create a rising, then falling, amplitude curve.

--- a/pyo/lib/mmlmusic.py
+++ b/pyo/lib/mmlmusic.py
@@ -22,7 +22,7 @@ Pre-Processing on music text
 
 - A musical voice is represented by a single line of code.
 
-- We can break a long line into multiple short lines with the backslash ( \ ).
+- We can break a long line into multiple short lines with the backslash ( \\ ).
 
 - The symbol equal ( = ), preceded by a variable name in UPPER CASE, creates a
   macro. The remaining part of the line is the macro body. Anywhere the 


### PR DESCRIPTION
Python emits following warnings:

```
pyo/examples/x22-events/08-function-calls.py:8: SyntaxWarning: invalid escape sequence '\*'
  EventCall calls a function, with any number of arguments (\*args) and uses
pyo/lib/mmlmusic.py:25: SyntaxWarning: invalid escape sequence '\ '
  - We can break a long line into multiple short lines with the backslash ( \ ).
```

Escape the backslashes in docstrings to fix those warnings.

Bug-Debian: https://bugs.debian.org/1086927