### PR TITLE
fix: correct lincese indication per standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Python module to build digital signal processing program."
 readme = "README.md"
 requires-python = ">=3.9, <4"
 keywords = ["audio", "sound", "dsp", "synthesis", "signal-processing", "music"]
-license = {text = "LGPLv3+"}
+license = "LGPL-3.0-or-later"
 classifiers = [
     # How mature is this project? Common values are
     #   3 - Alpha
@@ -26,8 +26,6 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    # Pick your license as you wish (should match "license" above)
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     # Topics
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Sound/Audio :: Analysis",


### PR DESCRIPTION
References: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license