### PR TITLE
Cast all return values from called functions to appropriate values.

### DIFF
--- a/include/pyomodule.h
+++ b/include/pyomodule.h
@@ -611,9 +611,9 @@ extern PyTypeObject MMLZStreamType;
     PyObject_HEAD \
     PyObject *server; \
     Stream *stream; \
-    void (*mode_func_ptr)(); \
-    void (*proc_func_ptr)(); \
-    void (*muladd_func_ptr)(); \
+    void (*mode_func_ptr)(void *); \
+    void (*proc_func_ptr)(void *); \
+    void (*muladd_func_ptr)(void *); \
     PyObject *mul; \
     Stream *mul_stream; \
     PyObject *add; \

--- a/include/streammodule.h
+++ b/include/streammodule.h
@@ -28,7 +28,7 @@ typedef struct
 {
     PyObject_HEAD
     PyObject *streamobject;
-    void (*funcptr)();
+    void (*funcptr)(void *);
     int sid;
     int chnl;
     int bufsize;

--- a/src/engine/dummymodule.c
+++ b/src/engine/dummymodule.c
@@ -45,39 +45,39 @@ Dummy_setProcMode(Dummy *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Dummy_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Dummy_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Dummy_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Dummy_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Dummy_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Dummy_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Dummy_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Dummy_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Dummy_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Dummy_postprocessing_revareva;
             break;
     }
 }
@@ -152,7 +152,7 @@ Dummy_initialize(Dummy *self)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Dummy_compute_next_data_frame);
-    self->mode_func_ptr = Dummy_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Dummy_setProcMode;
 
     PyObject_CallMethod(self->server, "addStream", "O", self->stream);
 
@@ -346,39 +346,39 @@ TriggerDummy_setProcMode(TriggerDummy *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TriggerDummy_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TriggerDummy_postprocessing_revareva;
             break;
     }
 }
@@ -435,7 +435,7 @@ TriggerDummy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TriggerDummy_compute_next_data_frame);
-    self->mode_func_ptr = TriggerDummy_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TriggerDummy_setProcMode;
 
     static char *kwlist[] = {"input", NULL};
 

--- a/src/engine/inputfadermodule.c
+++ b/src/engine/inputfadermodule.c
@@ -87,7 +87,7 @@ static void InputFader_process_one(InputFader *self)
     }
 
     if (val == 1.)
-        self->proc_func_ptr = InputFader_process_only_first;
+        self->proc_func_ptr = (void (*)(void *))InputFader_process_only_first;
 
 }
 
@@ -115,7 +115,7 @@ static void InputFader_process_two(InputFader *self)
     }
 
     if (val == 1.)
-        self->proc_func_ptr = InputFader_process_only_second;
+        self->proc_func_ptr = (void (*)(void *))InputFader_process_only_second;
 }
 
 static void
@@ -170,8 +170,8 @@ InputFader_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->sampleToSec = 1. / self->sr;
 
     Stream_setFunctionPtr(self->stream, InputFader_compute_next_data_frame);
-    self->mode_func_ptr = InputFader_setProcMode;
-    self->proc_func_ptr = InputFader_process_only_first;
+    self->mode_func_ptr = (void (*)(void *))InputFader_setProcMode;
+    self->proc_func_ptr = (void (*)(void *))InputFader_process_only_first;
 
     static char *kwlist[] = {"input", NULL};
 
@@ -220,7 +220,7 @@ InputFader_setInput(InputFader *self, PyObject *args, PyObject *kwds)
         streamtmp = PyObject_CallMethod((PyObject *)self->input1, "_getStream", NULL);
         self->input1_stream = (Stream *)streamtmp;
         Py_INCREF(self->input1_stream);
-        self->proc_func_ptr = InputFader_process_one;
+        self->proc_func_ptr = (void (*)(void *))InputFader_process_one;
     }
     else
     {
@@ -230,7 +230,7 @@ InputFader_setInput(InputFader *self, PyObject *args, PyObject *kwds)
         streamtmp = PyObject_CallMethod((PyObject *)self->input2, "_getStream", NULL);
         self->input2_stream = (Stream *)streamtmp;
         Py_INCREF(self->input2_stream);
-        self->proc_func_ptr = InputFader_process_two;
+        self->proc_func_ptr = (void (*)(void *))InputFader_process_two;
     }
 
     Py_RETURN_NONE;

--- a/src/engine/mixmodule.c
+++ b/src/engine/mixmodule.c
@@ -52,39 +52,39 @@ Mix_setProcMode(Mix *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Mix_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Mix_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Mix_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Mix_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Mix_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Mix_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Mix_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Mix_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Mix_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Mix_postprocessing_revareva;
             break;
     }
 }
@@ -158,7 +158,7 @@ Mix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Mix_compute_next_data_frame);
-    self->mode_func_ptr = Mix_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Mix_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 

--- a/src/engine/streammodule.c
+++ b/src/engine/streammodule.c
@@ -104,7 +104,7 @@ Stream_setData(Stream *self, MYFLT *data)
 
 void Stream_setFunctionPtr(Stream *self, void *ptr)
 {
-    self->funcptr = ptr;
+    self->funcptr = (void (*)(void *))ptr;
 }
 
 void Stream_callFunction(Stream *self)

--- a/src/objects/analysismodule.c
+++ b/src/objects/analysismodule.c
@@ -124,50 +124,50 @@ Follower_setProcMode(Follower *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Follower_filters_i;
+            self->proc_func_ptr = (void (*)(void *))Follower_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Follower_filters_a;
+            self->proc_func_ptr = (void (*)(void *))Follower_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Follower_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Follower_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Follower_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Follower_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Follower_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Follower_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Follower_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Follower_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Follower_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Follower_postprocessing_revareva;
             break;
     }
 }
@@ -224,7 +224,7 @@ Follower_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Follower_compute_next_data_frame);
-    self->mode_func_ptr = Follower_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Follower_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "mul", "add", NULL};
 
@@ -600,58 +600,58 @@ Follower2_setProcMode(Follower2 *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Follower2_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Follower2_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Follower2_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Follower2_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Follower2_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Follower2_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Follower2_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Follower2_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Follower2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Follower2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Follower2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Follower2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Follower2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Follower2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Follower2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Follower2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Follower2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Follower2_postprocessing_revareva;
             break;
     }
 }
@@ -713,7 +713,7 @@ Follower2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Follower2_compute_next_data_frame);
-    self->mode_func_ptr = Follower2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Follower2_setProcMode;
 
     self->mTwoPiOverSr = -TWOPI / self->sr;
 
@@ -940,44 +940,44 @@ ZCross_setProcMode(ZCross *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = ZCross_process;
+    self->proc_func_ptr = (void (*)(void *))ZCross_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ZCross_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ZCross_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ZCross_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ZCross_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ZCross_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ZCross_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ZCross_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ZCross_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ZCross_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ZCross_postprocessing_revareva;
             break;
     }
 }
@@ -1029,7 +1029,7 @@ ZCross_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, ZCross_compute_next_data_frame);
-    self->mode_func_ptr = ZCross_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ZCross_setProcMode;
 
     static char *kwlist[] = {"input", "thresh", "mul", "add", NULL};
 
@@ -1335,44 +1335,44 @@ Yin_setProcMode(Yin *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Yin_process;
+    self->proc_func_ptr = (void (*)(void *))Yin_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Yin_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Yin_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Yin_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Yin_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Yin_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Yin_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Yin_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Yin_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Yin_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Yin_postprocessing_revareva;
             break;
     }
 }
@@ -1434,7 +1434,7 @@ Yin_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Yin_compute_next_data_frame);
-    self->mode_func_ptr = Yin_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Yin_setProcMode;
 
     static char *kwlist[] = {"input", "tolerance", "minfreq", "maxfreq", "cutoff", "winsize", "mul", "add", NULL};
 
@@ -1763,44 +1763,44 @@ Centroid_setProcMode(Centroid *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Centroid_process_i;
+    self->proc_func_ptr = (void (*)(void *))Centroid_process_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Centroid_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Centroid_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Centroid_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Centroid_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Centroid_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Centroid_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Centroid_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Centroid_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Centroid_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Centroid_postprocessing_revareva;
             break;
     }
 }
@@ -1861,7 +1861,7 @@ Centroid_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->size = 1024;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Centroid_compute_next_data_frame);
-    self->mode_func_ptr = Centroid_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Centroid_setProcMode;
 
     static char *kwlist[] = {"input", "size", "mul", "add", NULL};
 
@@ -2133,44 +2133,44 @@ AttackDetector_setProcMode(AttackDetector *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = AttackDetector_process;
+    self->proc_func_ptr = (void (*)(void *))AttackDetector_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = AttackDetector_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = AttackDetector_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = AttackDetector_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = AttackDetector_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = AttackDetector_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = AttackDetector_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = AttackDetector_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = AttackDetector_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = AttackDetector_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))AttackDetector_postprocessing_revareva;
             break;
     }
 }
@@ -2233,7 +2233,7 @@ AttackDetector_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, AttackDetector_compute_next_data_frame);
-    self->mode_func_ptr = AttackDetector_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))AttackDetector_setProcMode;
 
     static char *kwlist[] = {"input", "deltime", "cutoff", "maxthresh", "minthresh", "reltime", "mul", "add", NULL};
 
@@ -2893,44 +2893,44 @@ PeakAmp_setProcMode(PeakAmp *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = PeakAmp_filters_i;
+    self->proc_func_ptr = (void (*)(void *))PeakAmp_filters_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = PeakAmp_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = PeakAmp_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = PeakAmp_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = PeakAmp_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = PeakAmp_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = PeakAmp_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = PeakAmp_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = PeakAmp_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = PeakAmp_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))PeakAmp_postprocessing_revareva;
             break;
     }
 }
@@ -2981,7 +2981,7 @@ PeakAmp_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PeakAmp_compute_next_data_frame);
-    self->mode_func_ptr = PeakAmp_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PeakAmp_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3181,44 +3181,44 @@ RMS_setProcMode(RMS *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = RMS_filters_i;
+    self->proc_func_ptr = (void (*)(void *))RMS_filters_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = RMS_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = RMS_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = RMS_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = RMS_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = RMS_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = RMS_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = RMS_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = RMS_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = RMS_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))RMS_postprocessing_revareva;
             break;
     }
 }
@@ -3269,7 +3269,7 @@ RMS_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RMS_compute_next_data_frame);
-    self->mode_func_ptr = RMS_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RMS_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 

--- a/src/objects/arithmeticmodule.c
+++ b/src/objects/arithmeticmodule.c
@@ -65,44 +65,44 @@ M_Sin_setProcMode(M_Sin *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Sin_process;
+    self->proc_func_ptr = (void (*)(void *))M_Sin_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Sin_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Sin_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Sin_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Sin_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Sin_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Sin_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Sin_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Sin_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Sin_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sin_postprocessing_revareva;
             break;
     }
 }
@@ -152,7 +152,7 @@ M_Sin_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Sin_compute_next_data_frame);
-    self->mode_func_ptr = M_Sin_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Sin_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -341,44 +341,44 @@ M_Cos_setProcMode(M_Cos *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Cos_process;
+    self->proc_func_ptr = (void (*)(void *))M_Cos_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Cos_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Cos_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Cos_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Cos_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Cos_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Cos_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Cos_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Cos_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Cos_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Cos_postprocessing_revareva;
             break;
     }
 }
@@ -428,7 +428,7 @@ M_Cos_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Cos_compute_next_data_frame);
-    self->mode_func_ptr = M_Cos_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Cos_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -617,44 +617,44 @@ M_Tan_setProcMode(M_Tan *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Tan_process;
+    self->proc_func_ptr = (void (*)(void *))M_Tan_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Tan_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Tan_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Tan_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Tan_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Tan_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Tan_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Tan_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Tan_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Tan_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tan_postprocessing_revareva;
             break;
     }
 }
@@ -704,7 +704,7 @@ M_Tan_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Tan_compute_next_data_frame);
-    self->mode_func_ptr = M_Tan_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Tan_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -899,44 +899,44 @@ M_Abs_setProcMode(M_Abs *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Abs_process;
+    self->proc_func_ptr = (void (*)(void *))M_Abs_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Abs_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Abs_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Abs_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Abs_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Abs_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Abs_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Abs_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Abs_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Abs_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Abs_postprocessing_revareva;
             break;
     }
 }
@@ -986,7 +986,7 @@ M_Abs_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Abs_compute_next_data_frame);
-    self->mode_func_ptr = M_Abs_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Abs_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -1181,44 +1181,44 @@ M_Sqrt_setProcMode(M_Sqrt *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Sqrt_process;
+    self->proc_func_ptr = (void (*)(void *))M_Sqrt_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Sqrt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sqrt_postprocessing_revareva;
             break;
     }
 }
@@ -1268,7 +1268,7 @@ M_Sqrt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Sqrt_compute_next_data_frame);
-    self->mode_func_ptr = M_Sqrt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Sqrt_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -1463,44 +1463,44 @@ M_Log_setProcMode(M_Log *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Log_process;
+    self->proc_func_ptr = (void (*)(void *))M_Log_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Log_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Log_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Log_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Log_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Log_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Log_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Log_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Log_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Log_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log_postprocessing_revareva;
             break;
     }
 }
@@ -1550,7 +1550,7 @@ M_Log_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Log_compute_next_data_frame);
-    self->mode_func_ptr = M_Log_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Log_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -1745,44 +1745,44 @@ M_Log10_setProcMode(M_Log10 *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Log10_process;
+    self->proc_func_ptr = (void (*)(void *))M_Log10_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Log10_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Log10_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Log10_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Log10_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Log10_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Log10_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Log10_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Log10_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Log10_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log10_postprocessing_revareva;
             break;
     }
 }
@@ -1832,7 +1832,7 @@ M_Log10_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Log10_compute_next_data_frame);
-    self->mode_func_ptr = M_Log10_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Log10_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -2027,44 +2027,44 @@ M_Log2_setProcMode(M_Log2 *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Log2_process;
+    self->proc_func_ptr = (void (*)(void *))M_Log2_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Log2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Log2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Log2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Log2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Log2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Log2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Log2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Log2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Log2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Log2_postprocessing_revareva;
             break;
     }
 }
@@ -2114,7 +2114,7 @@ M_Log2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Log2_compute_next_data_frame);
-    self->mode_func_ptr = M_Log2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Log2_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -2353,58 +2353,58 @@ M_Pow_setProcMode(M_Pow *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = M_Pow_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))M_Pow_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = M_Pow_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))M_Pow_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = M_Pow_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))M_Pow_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = M_Pow_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))M_Pow_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Pow_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Pow_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Pow_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Pow_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Pow_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Pow_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Pow_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Pow_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Pow_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Pow_postprocessing_revareva;
             break;
     }
 }
@@ -2460,7 +2460,7 @@ M_Pow_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Pow_compute_next_data_frame);
-    self->mode_func_ptr = M_Pow_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Pow_setProcMode;
 
     static char *kwlist[] = {"base", "exponent", "mul", "add", NULL};
 
@@ -2713,58 +2713,58 @@ M_Atan2_setProcMode(M_Atan2 *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = M_Atan2_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))M_Atan2_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = M_Atan2_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))M_Atan2_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = M_Atan2_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))M_Atan2_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = M_Atan2_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))M_Atan2_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Atan2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Atan2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Atan2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Atan2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Atan2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Atan2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Atan2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Atan2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Atan2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Atan2_postprocessing_revareva;
             break;
     }
 }
@@ -2820,7 +2820,7 @@ M_Atan2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Atan2_compute_next_data_frame);
-    self->mode_func_ptr = M_Atan2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Atan2_setProcMode;
 
     static char *kwlist[] = {"b", "a", "mul", "add", NULL};
 
@@ -3023,44 +3023,44 @@ M_Floor_setProcMode(M_Floor *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Floor_process;
+    self->proc_func_ptr = (void (*)(void *))M_Floor_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Floor_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Floor_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Floor_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Floor_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Floor_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Floor_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Floor_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Floor_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Floor_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Floor_postprocessing_revareva;
             break;
     }
 }
@@ -3110,7 +3110,7 @@ M_Floor_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Floor_compute_next_data_frame);
-    self->mode_func_ptr = M_Floor_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Floor_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3299,44 +3299,44 @@ M_Ceil_setProcMode(M_Ceil *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Ceil_process;
+    self->proc_func_ptr = (void (*)(void *))M_Ceil_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Ceil_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Ceil_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Ceil_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Ceil_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Ceil_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Ceil_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Ceil_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Ceil_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Ceil_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Ceil_postprocessing_revareva;
             break;
     }
 }
@@ -3386,7 +3386,7 @@ M_Ceil_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Ceil_compute_next_data_frame);
-    self->mode_func_ptr = M_Ceil_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Ceil_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3575,44 +3575,44 @@ M_Round_setProcMode(M_Round *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Round_process;
+    self->proc_func_ptr = (void (*)(void *))M_Round_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Round_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Round_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Round_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Round_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Round_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Round_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Round_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Round_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Round_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Round_postprocessing_revareva;
             break;
     }
 }
@@ -3662,7 +3662,7 @@ M_Round_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Round_compute_next_data_frame);
-    self->mode_func_ptr = M_Round_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Round_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3851,44 +3851,44 @@ M_Tanh_setProcMode(M_Tanh *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Tanh_process;
+    self->proc_func_ptr = (void (*)(void *))M_Tanh_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Tanh_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Tanh_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Tanh_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Tanh_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Tanh_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Tanh_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Tanh_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Tanh_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Tanh_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Tanh_postprocessing_revareva;
             break;
     }
 }
@@ -3938,7 +3938,7 @@ M_Tanh_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Tanh_compute_next_data_frame);
-    self->mode_func_ptr = M_Tanh_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Tanh_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -4127,44 +4127,44 @@ M_Exp_setProcMode(M_Exp *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = M_Exp_process;
+    self->proc_func_ptr = (void (*)(void *))M_Exp_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Exp_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Exp_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Exp_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Exp_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Exp_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Exp_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Exp_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Exp_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Exp_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Exp_postprocessing_revareva;
             break;
     }
 }
@@ -4214,7 +4214,7 @@ M_Exp_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Exp_compute_next_data_frame);
-    self->mode_func_ptr = M_Exp_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Exp_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -4480,58 +4480,58 @@ M_Div_setProcMode(M_Div *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = M_Div_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))M_Div_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = M_Div_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))M_Div_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = M_Div_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))M_Div_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = M_Div_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))M_Div_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Div_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Div_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Div_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Div_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Div_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Div_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Div_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Div_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Div_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Div_postprocessing_revareva;
             break;
     }
 }
@@ -4587,7 +4587,7 @@ M_Div_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Div_compute_next_data_frame);
-    self->mode_func_ptr = M_Div_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Div_setProcMode;
 
     static char *kwlist[] = {"a", "b", "mul", "add", NULL};
 
@@ -4840,58 +4840,58 @@ M_Sub_setProcMode(M_Sub *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = M_Sub_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))M_Sub_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = M_Sub_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))M_Sub_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = M_Sub_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))M_Sub_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = M_Sub_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))M_Sub_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = M_Sub_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = M_Sub_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = M_Sub_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = M_Sub_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = M_Sub_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = M_Sub_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = M_Sub_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = M_Sub_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = M_Sub_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))M_Sub_postprocessing_revareva;
             break;
     }
 }
@@ -4947,7 +4947,7 @@ M_Sub_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, M_Sub_compute_next_data_frame);
-    self->mode_func_ptr = M_Sub_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))M_Sub_setProcMode;
 
     static char *kwlist[] = {"a", "b", "mul", "add", NULL};
 

--- a/src/objects/bandsplitmodule.c
+++ b/src/objects/bandsplitmodule.c
@@ -173,11 +173,11 @@ BandSplitter_setProcMode(BandSplitter *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = BandSplitter_filters_i;
+            self->proc_func_ptr = (void (*)(void *))BandSplitter_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = BandSplitter_filters_a;
+            self->proc_func_ptr = (void (*)(void *))BandSplitter_filters_a;
             break;
     }
 }
@@ -241,7 +241,7 @@ BandSplitter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BandSplitter_compute_next_data_frame);
-    self->mode_func_ptr = BandSplitter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BandSplitter_setProcMode;
 
     self->halfSr = self->sr / 2.01;
     self->TwoPiOnSr = TWOPI / self->sr;
@@ -382,39 +382,39 @@ BandSplit_setProcMode(BandSplit *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BandSplit_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BandSplit_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BandSplit_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BandSplit_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BandSplit_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BandSplit_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BandSplit_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BandSplit_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BandSplit_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BandSplit_postprocessing_revareva;
             break;
     }
 }
@@ -474,7 +474,7 @@ BandSplit_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BandSplit_compute_next_data_frame);
-    self->mode_func_ptr = BandSplit_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BandSplit_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -866,7 +866,7 @@ FourBandMain_getSamplesBuffer(FourBandMain *self)
 static void
 FourBandMain_setProcMode(FourBandMain *self)
 {
-    self->proc_func_ptr = FourBandMain_filters;
+    self->proc_func_ptr = (void (*)(void *))FourBandMain_filters;
 }
 
 static void
@@ -926,7 +926,7 @@ FourBandMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FourBandMain_compute_next_data_frame);
-    self->mode_func_ptr = FourBandMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FourBandMain_setProcMode;
 
     static char *kwlist[] = {"input", "freq1", "freq2", "freq3", NULL};
 
@@ -1074,39 +1074,39 @@ FourBand_setProcMode(FourBand *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FourBand_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FourBand_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FourBand_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FourBand_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FourBand_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FourBand_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FourBand_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FourBand_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FourBand_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FourBand_postprocessing_revareva;
             break;
     }
 }
@@ -1166,7 +1166,7 @@ FourBand_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FourBand_compute_next_data_frame);
-    self->mode_func_ptr = FourBand_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FourBand_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -1530,7 +1530,7 @@ MultiBandMain_getSamplesBuffer(MultiBandMain *self)
 static void
 MultiBandMain_setProcMode(MultiBandMain *self)
 {
-    self->proc_func_ptr = MultiBandMain_filters;
+    self->proc_func_ptr = (void (*)(void *))MultiBandMain_filters;
 }
 
 static void
@@ -1575,7 +1575,7 @@ MultiBandMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MultiBandMain_compute_next_data_frame);
-    self->mode_func_ptr = MultiBandMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MultiBandMain_setProcMode;
 
     static char *kwlist[] = {"input", "num", NULL};
 
@@ -1732,39 +1732,39 @@ MultiBand_setProcMode(MultiBand *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MultiBand_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MultiBand_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MultiBand_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MultiBand_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MultiBand_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MultiBand_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MultiBand_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MultiBand_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MultiBand_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MultiBand_postprocessing_revareva;
             break;
     }
 }
@@ -1824,7 +1824,7 @@ MultiBand_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MultiBand_compute_next_data_frame);
-    self->mode_func_ptr = MultiBand_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MultiBand_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 

--- a/src/objects/chorusmodule.c
+++ b/src/objects/chorusmodule.c
@@ -51,7 +51,7 @@ typedef struct
     Stream *depth_stream;
     PyObject *mix;
     Stream *mix_stream;
-    void (*mix_func_ptr)();
+    void (*mix_func_ptr)(void *);
     int modebuffer[5];
     MYFLT total_signal;
     MYFLT delays[8];
@@ -375,69 +375,69 @@ Chorus_setProcMode(Chorus *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Chorus_process_ii;
+            self->proc_func_ptr = (void (*)(void *))Chorus_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Chorus_process_ai;
+            self->proc_func_ptr = (void (*)(void *))Chorus_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Chorus_process_ia;
+            self->proc_func_ptr = (void (*)(void *))Chorus_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Chorus_process_aa;
+            self->proc_func_ptr = (void (*)(void *))Chorus_process_aa;
             break;
     }
 
     switch (mixmode)
     {
         case 0:
-            self->mix_func_ptr = Chorus_mix_i;
+            self->mix_func_ptr = (void (*)(void *))Chorus_mix_i;
             break;
 
         case 1:
-            self->mix_func_ptr = Chorus_mix_a;
+            self->mix_func_ptr = (void (*)(void *))Chorus_mix_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Chorus_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Chorus_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Chorus_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Chorus_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Chorus_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Chorus_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Chorus_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Chorus_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Chorus_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Chorus_postprocessing_revareva;
             break;
     }
 }
@@ -511,7 +511,7 @@ Chorus_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Chorus_compute_next_data_frame);
-    self->mode_func_ptr = Chorus_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Chorus_setProcMode;
 
     srfac = self->sr / 44100.0;
 

--- a/src/objects/compressmodule.c
+++ b/src/objects/compressmodule.c
@@ -184,39 +184,39 @@ Compress_setProcMode(Compress *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Compress_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Compress_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Compress_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Compress_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Compress_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Compress_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Compress_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Compress_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Compress_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Compress_postprocessing_revareva;
             break;
     }
 }
@@ -290,7 +290,7 @@ Compress_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, Compress_compute_next_data_frame);
-    self->mode_func_ptr = Compress_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Compress_setProcMode;
 
     static char *kwlist[] = {"input", "thresh", "ratio", "risetime", "falltime", "lookahead", "knee", "outputAmp", "mul", "add", NULL};
 
@@ -340,7 +340,7 @@ Compress_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         self->lh_buffer[i] = 0.;
     }
 
-    self->proc_func_ptr = Compress_compress_soft;
+    self->proc_func_ptr = (void (*)(void *))Compress_compress_soft;
 
     PyObject_CallMethod(self->server, "addStream", "O", self->stream);
 
@@ -1128,74 +1128,74 @@ Gate_setProcMode(Gate *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Gate_filters_iii;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Gate_filters_aii;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Gate_filters_iai;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Gate_filters_aai;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Gate_filters_iia;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Gate_filters_aia;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Gate_filters_iaa;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Gate_filters_aaa;
+            self->proc_func_ptr = (void (*)(void *))Gate_filters_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Gate_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Gate_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Gate_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Gate_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Gate_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Gate_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Gate_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Gate_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Gate_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Gate_postprocessing_revareva;
             break;
     }
 }
@@ -1269,7 +1269,7 @@ Gate_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->lpfactor = MYEXP(-1.0 / (self->sr / 20.0));
 
     Stream_setFunctionPtr(self->stream, Gate_compute_next_data_frame);
-    self->mode_func_ptr = Gate_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Gate_setProcMode;
 
     static char *kwlist[] = {"input", "thresh", "risetime", "falltime", "lookahead", "outputAmp", "mul", "add", NULL};
 
@@ -1596,50 +1596,50 @@ Balance_setProcMode(Balance *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Balance_filters_i;
+            self->proc_func_ptr = (void (*)(void *))Balance_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Balance_filters_a;
+            self->proc_func_ptr = (void (*)(void *))Balance_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Balance_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Balance_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Balance_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Balance_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Balance_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Balance_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Balance_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Balance_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Balance_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Balance_postprocessing_revareva;
             break;
     }
 }
@@ -1698,7 +1698,7 @@ Balance_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Balance_compute_next_data_frame);
-    self->mode_func_ptr = Balance_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Balance_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "freq", "mul", "add", NULL};
 
@@ -2012,39 +2012,39 @@ Expand_setProcMode(Expand *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Expand_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Expand_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Expand_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Expand_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Expand_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Expand_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Expand_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Expand_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Expand_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Expand_postprocessing_revareva;
             break;
     }
 }
@@ -2121,7 +2121,7 @@ Expand_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, Expand_compute_next_data_frame);
-    self->mode_func_ptr = Expand_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Expand_setProcMode;
 
     static char *kwlist[] = {"input", "downthresh", "upthresh", "ratio", "risetime", "falltime", "lookahead", "outputAmp", "mul", "add", NULL};
 
@@ -2175,7 +2175,7 @@ Expand_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         self->lh_buffer[i] = 0.;
     }
 
-    self->proc_func_ptr = Expand_compress_soft;
+    self->proc_func_ptr = (void (*)(void *))Expand_compress_soft;
 
     PyObject_CallMethod(self->server, "addStream", "O", self->stream);
 

--- a/src/objects/convolvemodule.c
+++ b/src/objects/convolvemodule.c
@@ -89,44 +89,44 @@ Convolve_setProcMode(Convolve *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Convolve_filters;
+    self->proc_func_ptr = (void (*)(void *))Convolve_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Convolve_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Convolve_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Convolve_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Convolve_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Convolve_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Convolve_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Convolve_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Convolve_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Convolve_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Convolve_postprocessing_revareva;
             break;
     }
 }
@@ -178,7 +178,7 @@ Convolve_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Convolve_compute_next_data_frame);
-    self->mode_func_ptr = Convolve_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Convolve_setProcMode;
 
     static char *kwlist[] = {"input", "table", "size", "mul", "add", NULL};
 
@@ -599,44 +599,44 @@ IRWinSinc_setProcMode(IRWinSinc *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IRWinSinc_filters;
+    self->proc_func_ptr = (void (*)(void *))IRWinSinc_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IRWinSinc_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IRWinSinc_postprocessing_revareva;
             break;
     }
 }
@@ -703,7 +703,7 @@ IRWinSinc_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IRWinSinc_compute_next_data_frame);
-    self->mode_func_ptr = IRWinSinc_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IRWinSinc_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "bw", "type", "order", "mul", "add", NULL};
 
@@ -978,44 +978,44 @@ IRAverage_setProcMode(IRAverage *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IRAverage_filters;
+    self->proc_func_ptr = (void (*)(void *))IRAverage_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IRAverage_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IRAverage_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IRAverage_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IRAverage_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IRAverage_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IRAverage_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IRAverage_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IRAverage_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IRAverage_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IRAverage_postprocessing_revareva;
             break;
     }
 }
@@ -1069,7 +1069,7 @@ IRAverage_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IRAverage_compute_next_data_frame);
-    self->mode_func_ptr = IRAverage_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IRAverage_setProcMode;
 
     static char *kwlist[] = {"input", "order", "mul", "add", NULL};
 
@@ -1490,44 +1490,44 @@ IRPulse_setProcMode(IRPulse *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IRPulse_filters;
+    self->proc_func_ptr = (void (*)(void *))IRPulse_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IRPulse_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IRPulse_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IRPulse_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IRPulse_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IRPulse_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IRPulse_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IRPulse_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IRPulse_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IRPulse_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IRPulse_postprocessing_revareva;
             break;
     }
 }
@@ -1593,7 +1593,7 @@ IRPulse_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IRPulse_compute_next_data_frame);
-    self->mode_func_ptr = IRPulse_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IRPulse_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "bw", "type", "order", "mul", "add", NULL};
 
@@ -1941,44 +1941,44 @@ IRFM_setProcMode(IRFM *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IRFM_filters;
+    self->proc_func_ptr = (void (*)(void *))IRFM_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IRFM_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IRFM_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IRFM_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IRFM_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IRFM_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IRFM_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IRFM_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IRFM_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IRFM_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IRFM_postprocessing_revareva;
             break;
     }
 }
@@ -2047,7 +2047,7 @@ IRFM_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IRFM_compute_next_data_frame);
-    self->mode_func_ptr = IRFM_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IRFM_setProcMode;
 
     static char *kwlist[] = {"input", "carrier", "ratio", "index", "order", "mul", "add", NULL};
 

--- a/src/objects/delaymodule.c
+++ b/src/objects/delaymodule.c
@@ -261,58 +261,58 @@ Delay_setProcMode(Delay *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Delay_process_ii;
+            self->proc_func_ptr = (void (*)(void *))Delay_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Delay_process_ai;
+            self->proc_func_ptr = (void (*)(void *))Delay_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Delay_process_ia;
+            self->proc_func_ptr = (void (*)(void *))Delay_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Delay_process_aa;
+            self->proc_func_ptr = (void (*)(void *))Delay_process_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Delay_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Delay_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Delay_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Delay_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Delay_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Delay_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Delay_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Delay_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Delay_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Delay_postprocessing_revareva;
             break;
     }
 }
@@ -376,7 +376,7 @@ Delay_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->oneOverSr = 1.0 / self->sr;
 
     Stream_setFunctionPtr(self->stream, Delay_compute_next_data_frame);
-    self->mode_func_ptr = Delay_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Delay_setProcMode;
 
     static char *kwlist[] = {"input", "delay", "feedback", "maxdelay", "mul", "add", NULL};
 
@@ -690,50 +690,50 @@ SDelay_setProcMode(SDelay *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SDelay_process_i;
+            self->proc_func_ptr = (void (*)(void *))SDelay_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = SDelay_process_a;
+            self->proc_func_ptr = (void (*)(void *))SDelay_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SDelay_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SDelay_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SDelay_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SDelay_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SDelay_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SDelay_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SDelay_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SDelay_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SDelay_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SDelay_postprocessing_revareva;
             break;
     }
 }
@@ -790,7 +790,7 @@ SDelay_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SDelay_compute_next_data_frame);
-    self->mode_func_ptr = SDelay_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SDelay_setProcMode;
 
     static char *kwlist[] = {"input", "delay", "maxdelay", "mul", "add", NULL};
 
@@ -1397,58 +1397,58 @@ Waveguide_setProcMode(Waveguide *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Waveguide_process_ii;
+            self->proc_func_ptr = (void (*)(void *))Waveguide_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Waveguide_process_ai;
+            self->proc_func_ptr = (void (*)(void *))Waveguide_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Waveguide_process_ia;
+            self->proc_func_ptr = (void (*)(void *))Waveguide_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Waveguide_process_aa;
+            self->proc_func_ptr = (void (*)(void *))Waveguide_process_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Waveguide_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Waveguide_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Waveguide_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Waveguide_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Waveguide_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Waveguide_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Waveguide_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Waveguide_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Waveguide_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Waveguide_postprocessing_revareva;
             break;
     }
 }
@@ -1525,7 +1525,7 @@ Waveguide_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->nyquist = (MYFLT)self->sr * 0.45;
 
     Stream_setFunctionPtr(self->stream, Waveguide_compute_next_data_frame);
-    self->mode_func_ptr = Waveguide_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Waveguide_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "dur", "minfreq", "mul", "add", NULL};
 
@@ -2510,74 +2510,74 @@ AllpassWG_setProcMode(AllpassWG *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = AllpassWG_process_iii;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = AllpassWG_process_aii;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = AllpassWG_process_iai;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = AllpassWG_process_aai;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = AllpassWG_process_iia;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = AllpassWG_process_aia;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = AllpassWG_process_iaa;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = AllpassWG_process_aaa;
+            self->proc_func_ptr = (void (*)(void *))AllpassWG_process_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = AllpassWG_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = AllpassWG_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = AllpassWG_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = AllpassWG_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = AllpassWG_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = AllpassWG_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = AllpassWG_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = AllpassWG_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = AllpassWG_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))AllpassWG_postprocessing_revareva;
             break;
     }
 }
@@ -2654,7 +2654,7 @@ AllpassWG_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->nyquist = (MYFLT)self->sr * 0.45;
 
     Stream_setFunctionPtr(self->stream, AllpassWG_compute_next_data_frame);
-    self->mode_func_ptr = AllpassWG_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))AllpassWG_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "feed", "detune", "minfreq", "mul", "add", NULL};
 
@@ -2915,44 +2915,44 @@ Delay1_setProcMode(Delay1 *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Delay1_filters;
+    self->proc_func_ptr = (void (*)(void *))Delay1_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Delay1_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Delay1_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Delay1_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Delay1_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Delay1_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Delay1_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Delay1_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Delay1_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Delay1_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Delay1_postprocessing_revareva;
             break;
     }
 }
@@ -3003,7 +3003,7 @@ Delay1_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Delay1_compute_next_data_frame);
-    self->mode_func_ptr = Delay1_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Delay1_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3592,58 +3592,58 @@ SmoothDelay_setProcMode(SmoothDelay *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SmoothDelay_process_ii;
+            self->proc_func_ptr = (void (*)(void *))SmoothDelay_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = SmoothDelay_process_ai;
+            self->proc_func_ptr = (void (*)(void *))SmoothDelay_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = SmoothDelay_process_ia;
+            self->proc_func_ptr = (void (*)(void *))SmoothDelay_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = SmoothDelay_process_aa;
+            self->proc_func_ptr = (void (*)(void *))SmoothDelay_process_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SmoothDelay_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SmoothDelay_postprocessing_revareva;
             break;
     }
 }
@@ -3713,7 +3713,7 @@ SmoothDelay_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->oneOverSr = self->sampdel1 = self->sampdel2 = 1.0 / self->sr;
 
     Stream_setFunctionPtr(self->stream, SmoothDelay_compute_next_data_frame);
-    self->mode_func_ptr = SmoothDelay_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SmoothDelay_setProcMode;
 
     static char *kwlist[] = {"input", "delay", "feedback", "crossfade", "maxdelay", "mul", "add", NULL};
 

--- a/src/objects/distomodule.c
+++ b/src/objects/distomodule.c
@@ -173,58 +173,58 @@ Disto_setProcMode(Disto *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Disto_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Disto_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Disto_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Disto_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Disto_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Disto_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Disto_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Disto_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Disto_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Disto_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Disto_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Disto_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Disto_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Disto_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Disto_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Disto_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Disto_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Disto_postprocessing_revareva;
             break;
     }
 }
@@ -283,7 +283,7 @@ Disto_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Disto_compute_next_data_frame);
-    self->mode_func_ptr = Disto_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Disto_setProcMode;
 
     static char *kwlist[] = {"input", "drive", "slope", "mul", "add", NULL};
 
@@ -578,58 +578,58 @@ Clip_setProcMode(Clip *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Clip_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Clip_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Clip_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Clip_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Clip_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Clip_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Clip_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Clip_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Clip_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Clip_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Clip_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Clip_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Clip_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Clip_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Clip_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Clip_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Clip_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Clip_postprocessing_revareva;
             break;
     }
 }
@@ -687,7 +687,7 @@ Clip_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Clip_compute_next_data_frame);
-    self->mode_func_ptr = Clip_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Clip_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "mul", "add", NULL};
 
@@ -1030,58 +1030,58 @@ Mirror_setProcMode(Mirror *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Mirror_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Mirror_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Mirror_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Mirror_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Mirror_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Mirror_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Mirror_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Mirror_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Mirror_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Mirror_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Mirror_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Mirror_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Mirror_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Mirror_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Mirror_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Mirror_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Mirror_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Mirror_postprocessing_revareva;
             break;
     }
 }
@@ -1139,7 +1139,7 @@ Mirror_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Mirror_compute_next_data_frame);
-    self->mode_func_ptr = Mirror_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Mirror_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "mul", "add", NULL};
 
@@ -1518,58 +1518,58 @@ Wrap_setProcMode(Wrap *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Wrap_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Wrap_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Wrap_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Wrap_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Wrap_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Wrap_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Wrap_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Wrap_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Wrap_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Wrap_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Wrap_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Wrap_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Wrap_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Wrap_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Wrap_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Wrap_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Wrap_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Wrap_postprocessing_revareva;
             break;
     }
 }
@@ -1627,7 +1627,7 @@ Wrap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Wrap_compute_next_data_frame);
-    self->mode_func_ptr = Wrap_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Wrap_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "mul", "add", NULL};
 
@@ -1975,58 +1975,58 @@ Degrade_setProcMode(Degrade *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Degrade_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Degrade_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Degrade_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Degrade_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Degrade_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Degrade_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Degrade_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Degrade_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Degrade_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Degrade_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Degrade_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Degrade_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Degrade_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Degrade_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Degrade_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Degrade_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Degrade_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Degrade_postprocessing_revareva;
             break;
     }
 }
@@ -2086,7 +2086,7 @@ Degrade_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Degrade_compute_next_data_frame);
-    self->mode_func_ptr = Degrade_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Degrade_setProcMode;
 
     static char *kwlist[] = {"input", "bitdepth", "srscale", "mul", "add", NULL};
 
@@ -2312,50 +2312,50 @@ Min_setProcMode(Min *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Min_process_i;
+            self->proc_func_ptr = (void (*)(void *))Min_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Min_process_a;
+            self->proc_func_ptr = (void (*)(void *))Min_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Min_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Min_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Min_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Min_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Min_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Min_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Min_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Min_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Min_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Min_postprocessing_revareva;
             break;
     }
 }
@@ -2410,7 +2410,7 @@ Min_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, Min_compute_next_data_frame);
-    self->mode_func_ptr = Min_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Min_setProcMode;
 
     static char *kwlist[] = {"input", "comp", "mul", "add", NULL};
 
@@ -2628,50 +2628,50 @@ Max_setProcMode(Max *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Max_process_i;
+            self->proc_func_ptr = (void (*)(void *))Max_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Max_process_a;
+            self->proc_func_ptr = (void (*)(void *))Max_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Max_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Max_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Max_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Max_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Max_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Max_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Max_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Max_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Max_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Max_postprocessing_revareva;
             break;
     }
 }
@@ -2726,7 +2726,7 @@ Max_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, Max_compute_next_data_frame);
-    self->mode_func_ptr = Max_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Max_setProcMode;
 
     static char *kwlist[] = {"input", "comp", "mul", "add", NULL};
 

--- a/src/objects/exprmodule.c
+++ b/src/objects/exprmodule.c
@@ -723,7 +723,7 @@ Exprer_getSamplesBuffer(Exprer *self)
 static void
 Exprer_setProcMode(Exprer *self)
 {
-    self->proc_func_ptr = Exprer_process;
+    self->proc_func_ptr = (void (*)(void *))Exprer_process;
 }
 
 static void
@@ -779,7 +779,7 @@ Exprer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Exprer_compute_next_data_frame);
-    self->mode_func_ptr = Exprer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Exprer_setProcMode;
 
     self->oneOverSr = 1.0 / self->sr;
 
@@ -1281,39 +1281,39 @@ Expr_setProcMode(Expr *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Expr_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Expr_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Expr_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Expr_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Expr_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Expr_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Expr_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Expr_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Expr_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Expr_postprocessing_revareva;
             break;
     }
 }
@@ -1372,7 +1372,7 @@ Expr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Expr_compute_next_data_frame);
-    self->mode_func_ptr = Expr_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Expr_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 

--- a/src/objects/fadermodule.c
+++ b/src/objects/fadermodule.c
@@ -181,46 +181,46 @@ Fader_setProcMode(Fader *self)
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
     if (self->duration == 0.0)
-        self->proc_func_ptr = Fader_generate_wait;
+        self->proc_func_ptr = (void (*)(void *))Fader_generate_wait;
     else
-        self->proc_func_ptr = Fader_generate_auto;
+        self->proc_func_ptr = (void (*)(void *))Fader_generate_auto;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Fader_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Fader_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Fader_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Fader_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Fader_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Fader_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Fader_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Fader_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Fader_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Fader_postprocessing_revareva;
             break;
     }
 }
@@ -280,7 +280,7 @@ Fader_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Fader_compute_next_data_frame);
-    self->mode_func_ptr = Fader_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Fader_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -657,46 +657,46 @@ Adsr_setProcMode(Adsr *self)
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
     if (self->duration == 0.0)
-        self->proc_func_ptr = Adsr_generate_wait;
+        self->proc_func_ptr = (void (*)(void *))Adsr_generate_wait;
     else
-        self->proc_func_ptr = Adsr_generate_auto;
+        self->proc_func_ptr = (void (*)(void *))Adsr_generate_auto;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Adsr_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Adsr_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Adsr_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Adsr_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Adsr_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Adsr_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Adsr_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Adsr_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Adsr_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Adsr_postprocessing_revareva;
             break;
     }
 }
@@ -758,7 +758,7 @@ Adsr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Adsr_compute_next_data_frame);
-    self->mode_func_ptr = Adsr_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Adsr_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -1164,44 +1164,44 @@ Linseg_setProcMode(Linseg *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Linseg_generate;
+    self->proc_func_ptr = (void (*)(void *))Linseg_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Linseg_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Linseg_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Linseg_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Linseg_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Linseg_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Linseg_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Linseg_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Linseg_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Linseg_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Linseg_postprocessing_revareva;
             break;
     }
 }
@@ -1256,7 +1256,7 @@ Linseg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Linseg_compute_next_data_frame);
-    self->mode_func_ptr = Linseg_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Linseg_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -1628,44 +1628,44 @@ Expseg_setProcMode(Expseg *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Expseg_generate;
+    self->proc_func_ptr = (void (*)(void *))Expseg_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Expseg_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Expseg_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Expseg_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Expseg_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Expseg_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Expseg_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Expseg_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Expseg_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Expseg_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Expseg_postprocessing_revareva;
             break;
     }
 }
@@ -1722,7 +1722,7 @@ Expseg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Expseg_compute_next_data_frame);
-    self->mode_func_ptr = Expseg_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Expseg_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 

--- a/src/objects/fftmodule.c
+++ b/src/objects/fftmodule.c
@@ -166,7 +166,7 @@ FFTMain_getSamplesBuffer(FFTMain *self)
 static void
 FFTMain_setProcMode(FFTMain *self)
 {
-    self->proc_func_ptr = FFTMain_filters;
+    self->proc_func_ptr = (void (*)(void *))FFTMain_filters;
 }
 
 static void
@@ -226,7 +226,7 @@ FFTMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FFTMain_compute_next_data_frame);
-    self->mode_func_ptr = FFTMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FFTMain_setProcMode;
 
     static char *kwlist[] = {"input", "size", "hopsize", "wintype", NULL};
 
@@ -377,39 +377,39 @@ FFT_setProcMode(FFT *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FFT_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FFT_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FFT_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FFT_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FFT_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FFT_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FFT_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FFT_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FFT_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FFT_postprocessing_revareva;
             break;
     }
 }
@@ -468,7 +468,7 @@ FFT_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FFT_compute_next_data_frame);
-    self->mode_func_ptr = FFT_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FFT_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -742,44 +742,44 @@ IFFT_setProcMode(IFFT *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IFFT_filters;
+    self->proc_func_ptr = (void (*)(void *))IFFT_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IFFT_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IFFT_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IFFT_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IFFT_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IFFT_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IFFT_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IFFT_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IFFT_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IFFT_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IFFT_postprocessing_revareva;
             break;
     }
 }
@@ -846,7 +846,7 @@ IFFT_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IFFT_compute_next_data_frame);
-    self->mode_func_ptr = IFFT_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IFFT_setProcMode;
 
     static char *kwlist[] = {"inreal", "inimag", "size", "hopsize", "wintype", "mul", "add", NULL};
 
@@ -1097,44 +1097,44 @@ CarToPol_setProcMode(CarToPol *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = CarToPol_generate;
+    self->proc_func_ptr = (void (*)(void *))CarToPol_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = CarToPol_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = CarToPol_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = CarToPol_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = CarToPol_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = CarToPol_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = CarToPol_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = CarToPol_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = CarToPol_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = CarToPol_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))CarToPol_postprocessing_revareva;
             break;
     }
 }
@@ -1186,7 +1186,7 @@ CarToPol_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CarToPol_compute_next_data_frame);
-    self->mode_func_ptr = CarToPol_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CarToPol_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "chnl", "mul", "add", NULL};
 
@@ -1391,44 +1391,44 @@ PolToCar_setProcMode(PolToCar *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = PolToCar_generate;
+    self->proc_func_ptr = (void (*)(void *))PolToCar_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = PolToCar_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = PolToCar_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = PolToCar_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = PolToCar_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = PolToCar_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = PolToCar_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = PolToCar_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = PolToCar_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = PolToCar_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))PolToCar_postprocessing_revareva;
             break;
     }
 }
@@ -1480,7 +1480,7 @@ PolToCar_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PolToCar_compute_next_data_frame);
-    self->mode_func_ptr = PolToCar_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PolToCar_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "chnl", "mul", "add", NULL};
 
@@ -1715,7 +1715,7 @@ FrameDeltaMain_getSamplesBuffer(FrameDeltaMain *self)
 static void
 FrameDeltaMain_setProcMode(FrameDeltaMain *self)
 {
-    self->proc_func_ptr = FrameDeltaMain_generate;
+    self->proc_func_ptr = (void (*)(void *))FrameDeltaMain_generate;
 }
 
 static void
@@ -1771,7 +1771,7 @@ FrameDeltaMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FrameDeltaMain_compute_next_data_frame);
-    self->mode_func_ptr = FrameDeltaMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FrameDeltaMain_setProcMode;
 
     static char *kwlist[] = {"input", "frameSize", "overlaps", NULL};
 
@@ -1961,39 +1961,39 @@ FrameDelta_setProcMode(FrameDelta *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FrameDelta_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FrameDelta_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FrameDelta_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FrameDelta_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FrameDelta_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FrameDelta_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FrameDelta_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FrameDelta_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FrameDelta_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FrameDelta_postprocessing_revareva;
             break;
     }
 }
@@ -2052,7 +2052,7 @@ FrameDelta_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FrameDelta_compute_next_data_frame);
-    self->mode_func_ptr = FrameDelta_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FrameDelta_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -2271,7 +2271,7 @@ FrameAccumMain_getSamplesBuffer(FrameAccumMain *self)
 static void
 FrameAccumMain_setProcMode(FrameAccumMain *self)
 {
-    self->proc_func_ptr = FrameAccumMain_generate;
+    self->proc_func_ptr = (void (*)(void *))FrameAccumMain_generate;
 }
 
 static void
@@ -2327,7 +2327,7 @@ FrameAccumMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FrameAccumMain_compute_next_data_frame);
-    self->mode_func_ptr = FrameAccumMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FrameAccumMain_setProcMode;
 
     static char *kwlist[] = {"input", "framesize", "overlaps", NULL};
 
@@ -2517,39 +2517,39 @@ FrameAccum_setProcMode(FrameAccum *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FrameAccum_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FrameAccum_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FrameAccum_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FrameAccum_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FrameAccum_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FrameAccum_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FrameAccum_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FrameAccum_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FrameAccum_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FrameAccum_postprocessing_revareva;
             break;
     }
 }
@@ -2608,7 +2608,7 @@ FrameAccum_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FrameAccum_compute_next_data_frame);
-    self->mode_func_ptr = FrameAccum_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FrameAccum_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -2883,7 +2883,7 @@ VectralMain_getSamplesBuffer(VectralMain *self)
 static void
 VectralMain_setProcMode(VectralMain *self)
 {
-    self->proc_func_ptr = VectralMain_generate;
+    self->proc_func_ptr = (void (*)(void *))VectralMain_generate;
 }
 
 static void
@@ -2953,7 +2953,7 @@ VectralMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, VectralMain_compute_next_data_frame);
-    self->mode_func_ptr = VectralMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))VectralMain_setProcMode;
 
     static char *kwlist[] = {"input", "frameSize", "overlaps", "up", "down", "damp", NULL};
 
@@ -3165,39 +3165,39 @@ Vectral_setProcMode(Vectral *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Vectral_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Vectral_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Vectral_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Vectral_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Vectral_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Vectral_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Vectral_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Vectral_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Vectral_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Vectral_postprocessing_revareva;
             break;
     }
 }
@@ -3256,7 +3256,7 @@ Vectral_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Vectral_compute_next_data_frame);
-    self->mode_func_ptr = Vectral_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Vectral_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -3759,50 +3759,50 @@ CvlVerb_setProcMode(CvlVerb *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = CvlVerb_process_i;
+            self->proc_func_ptr = (void (*)(void *))CvlVerb_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = CvlVerb_process_a;
+            self->proc_func_ptr = (void (*)(void *))CvlVerb_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = CvlVerb_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = CvlVerb_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = CvlVerb_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = CvlVerb_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = CvlVerb_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = CvlVerb_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = CvlVerb_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = CvlVerb_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = CvlVerb_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))CvlVerb_postprocessing_revareva;
             break;
     }
 }
@@ -3885,7 +3885,7 @@ CvlVerb_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->current_iter = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CvlVerb_compute_next_data_frame);
-    self->mode_func_ptr = CvlVerb_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CvlVerb_setProcMode;
 
     static char *kwlist[] = {"input", "impulse", "bal", "size", "chnl", "mul", "add", NULL};
 
@@ -4280,7 +4280,7 @@ Spectrum_filters(Spectrum *self)
 static void
 Spectrum_setProcMode(Spectrum *self)
 {
-    self->proc_func_ptr = Spectrum_filters;
+    self->proc_func_ptr = (void (*)(void *))Spectrum_filters;
 }
 
 static void
@@ -4353,7 +4353,7 @@ Spectrum_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
 
     Stream_setFunctionPtr(self->stream, Spectrum_compute_next_data_frame);
-    self->mode_func_ptr = Spectrum_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Spectrum_setProcMode;
 
     static char *kwlist[] = {"input", "size", "wintype", NULL};
 
@@ -4694,44 +4694,44 @@ IFFTMatrix_setProcMode(IFFTMatrix *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = IFFTMatrix_filters;
+    self->proc_func_ptr = (void (*)(void *))IFFTMatrix_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = IFFTMatrix_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))IFFTMatrix_postprocessing_revareva;
             break;
     }
 }
@@ -4801,7 +4801,7 @@ IFFTMatrix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, IFFTMatrix_compute_next_data_frame);
-    self->mode_func_ptr = IFFTMatrix_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))IFFTMatrix_setProcMode;
 
     static char *kwlist[] = {"matrix", "index", "phase", "size", "hopsize", "wintype", "mul", "add", NULL};
 

--- a/src/objects/filtremodule.c
+++ b/src/objects/filtremodule.c
@@ -37,7 +37,7 @@ typedef struct
     Stream *freq_stream;
     PyObject *q;
     Stream *q_stream;
-    void (*coeffs_func_ptr)();
+    void (*coeffs_func_ptr)(void *);
     int init;
     int modebuffer[4]; // need at least 2 slots for mul & add
     int filtertype;
@@ -253,23 +253,23 @@ Biquad_setProcMode(Biquad *self)
     switch (self->filtertype)
     {
         case 0:
-            self->coeffs_func_ptr = Biquad_compute_coeffs_lp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquad_compute_coeffs_lp;
             break;
 
         case 1:
-            self->coeffs_func_ptr = Biquad_compute_coeffs_hp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquad_compute_coeffs_hp;
             break;
 
         case 2:
-            self->coeffs_func_ptr = Biquad_compute_coeffs_bp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquad_compute_coeffs_bp;
             break;
 
         case 3:
-            self->coeffs_func_ptr = Biquad_compute_coeffs_bs;
+            self->coeffs_func_ptr = (void (*)(void *))Biquad_compute_coeffs_bs;
             break;
 
         case 4:
-            self->coeffs_func_ptr = Biquad_compute_coeffs_ap;
+            self->coeffs_func_ptr = (void (*)(void *))Biquad_compute_coeffs_ap;
             break;
     }
 
@@ -277,58 +277,58 @@ Biquad_setProcMode(Biquad *self)
     {
         case 0:
             Biquad_compute_variables(self, PyFloat_AS_DOUBLE(self->freq), PyFloat_AS_DOUBLE(self->q));
-            self->proc_func_ptr = Biquad_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Biquad_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Biquad_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Biquad_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Biquad_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Biquad_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Biquad_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Biquad_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Biquad_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Biquad_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Biquad_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Biquad_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Biquad_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Biquad_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Biquad_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Biquad_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Biquad_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Biquad_postprocessing_revareva;
             break;
     }
 }
@@ -392,7 +392,7 @@ Biquad_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->twoPiOverSr = TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, Biquad_compute_next_data_frame);
-    self->mode_func_ptr = Biquad_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Biquad_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "type", "mul", "add", NULL};
 
@@ -584,7 +584,7 @@ typedef struct
     Stream *freq_stream;
     PyObject *q;
     Stream *q_stream;
-    void (*coeffs_func_ptr)();
+    void (*coeffs_func_ptr)(void *);
     int init;
     int modebuffer[4]; // need at least 2 slots for mul & add
     int filtertype;
@@ -862,23 +862,23 @@ Biquadx_setProcMode(Biquadx *self)
     switch (self->filtertype)
     {
         case 0:
-            self->coeffs_func_ptr = Biquadx_compute_coeffs_lp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquadx_compute_coeffs_lp;
             break;
 
         case 1:
-            self->coeffs_func_ptr = Biquadx_compute_coeffs_hp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquadx_compute_coeffs_hp;
             break;
 
         case 2:
-            self->coeffs_func_ptr = Biquadx_compute_coeffs_bp;
+            self->coeffs_func_ptr = (void (*)(void *))Biquadx_compute_coeffs_bp;
             break;
 
         case 3:
-            self->coeffs_func_ptr = Biquadx_compute_coeffs_bs;
+            self->coeffs_func_ptr = (void (*)(void *))Biquadx_compute_coeffs_bs;
             break;
 
         case 4:
-            self->coeffs_func_ptr = Biquadx_compute_coeffs_ap;
+            self->coeffs_func_ptr = (void (*)(void *))Biquadx_compute_coeffs_ap;
             break;
     }
 
@@ -886,58 +886,58 @@ Biquadx_setProcMode(Biquadx *self)
     {
         case 0:
             Biquadx_compute_variables(self, PyFloat_AS_DOUBLE(self->freq), PyFloat_AS_DOUBLE(self->q));
-            self->proc_func_ptr = Biquadx_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Biquadx_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Biquadx_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Biquadx_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Biquadx_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Biquadx_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Biquadx_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Biquadx_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Biquadx_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Biquadx_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Biquadx_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Biquadx_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Biquadx_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Biquadx_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Biquadx_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Biquadx_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Biquadx_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Biquadx_postprocessing_revareva;
             break;
     }
 }
@@ -1005,7 +1005,7 @@ Biquadx_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->nyquist = (MYFLT)self->sr * 0.49;
 
     Stream_setFunctionPtr(self->stream, Biquadx_compute_next_data_frame);
-    self->mode_func_ptr = Biquadx_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Biquadx_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "type", "stages", "mul", "add", NULL};
 
@@ -1272,44 +1272,44 @@ Biquada_setProcMode(Biquada *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Biquada_filters;
+    self->proc_func_ptr = (void (*)(void *))Biquada_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Biquada_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Biquada_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Biquada_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Biquada_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Biquada_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Biquada_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Biquada_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Biquada_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Biquada_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Biquada_postprocessing_revareva;
             break;
     }
 }
@@ -1361,7 +1361,7 @@ Biquada_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, Biquada_compute_next_data_frame);
-    self->mode_func_ptr = Biquada_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Biquada_setProcMode;
 
     static char *kwlist[] = {"input", "b0", "b1", "b2", "a0", "a1", "a2", "mul", "add", NULL};
 
@@ -1619,7 +1619,7 @@ typedef struct
     Stream *q_stream;
     PyObject *boost;
     Stream *boost_stream;
-    void (*coeffs_func_ptr)();
+    void (*coeffs_func_ptr)(void *);
     int init;
     int modebuffer[5]; // need at least 2 slots for mul & add
     int filtertype;
@@ -1941,15 +1941,15 @@ EQ_setProcMode(EQ *self)
     switch (self->filtertype)
     {
         case 0:
-            self->coeffs_func_ptr = EQ_compute_coeffs_peak;
+            self->coeffs_func_ptr = (void (*)(void *))EQ_compute_coeffs_peak;
             break;
 
         case 1:
-            self->coeffs_func_ptr = EQ_compute_coeffs_lowshelf;
+            self->coeffs_func_ptr = (void (*)(void *))EQ_compute_coeffs_lowshelf;
             break;
 
         case 2:
-            self->coeffs_func_ptr = EQ_compute_coeffs_highshelf;
+            self->coeffs_func_ptr = (void (*)(void *))EQ_compute_coeffs_highshelf;
             break;
     }
 
@@ -1957,74 +1957,74 @@ EQ_setProcMode(EQ *self)
     {
         case 0:
             EQ_compute_variables(self, PyFloat_AS_DOUBLE(self->freq), PyFloat_AS_DOUBLE(self->q), PyFloat_AS_DOUBLE(self->boost));
-            self->proc_func_ptr = EQ_filters_iii;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = EQ_filters_aii;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = EQ_filters_iai;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = EQ_filters_aai;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = EQ_filters_iia;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = EQ_filters_aia;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = EQ_filters_iaa;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = EQ_filters_aaa;
+            self->proc_func_ptr = (void (*)(void *))EQ_filters_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = EQ_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = EQ_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = EQ_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = EQ_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = EQ_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = EQ_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = EQ_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = EQ_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = EQ_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))EQ_postprocessing_revareva;
             break;
     }
 }
@@ -2092,7 +2092,7 @@ EQ_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->twoPiOverSr = TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, EQ_compute_next_data_frame);
-    self->mode_func_ptr = EQ_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))EQ_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "boost", "type", "mul", "add", NULL};
 
@@ -2452,58 +2452,58 @@ Port_setProcMode(Port *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Port_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Port_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Port_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Port_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Port_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Port_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Port_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Port_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Port_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Port_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Port_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Port_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Port_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Port_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Port_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Port_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Port_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Port_postprocessing_revareva;
             break;
     }
 }
@@ -2565,7 +2565,7 @@ Port_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Port_compute_next_data_frame);
-    self->mode_func_ptr = Port_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Port_setProcMode;
 
     static char *kwlist[] = {"input", "risetime", "falltime", "init", "mul", "add", NULL};
 
@@ -2826,50 +2826,50 @@ Tone_setProcMode(Tone *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Tone_filters_i;
+            self->proc_func_ptr = (void (*)(void *))Tone_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Tone_filters_a;
+            self->proc_func_ptr = (void (*)(void *))Tone_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Tone_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Tone_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Tone_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Tone_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Tone_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Tone_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Tone_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Tone_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Tone_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Tone_postprocessing_revareva;
             break;
     }
 }
@@ -2929,7 +2929,7 @@ Tone_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->mTwoPiOverSr = -TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, Tone_compute_next_data_frame);
-    self->mode_func_ptr = Tone_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Tone_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "mul", "add", NULL};
 
@@ -3181,50 +3181,50 @@ Atone_setProcMode(Atone *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Atone_filters_i;
+            self->proc_func_ptr = (void (*)(void *))Atone_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Atone_filters_a;
+            self->proc_func_ptr = (void (*)(void *))Atone_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Atone_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Atone_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Atone_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Atone_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Atone_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Atone_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Atone_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Atone_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Atone_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Atone_postprocessing_revareva;
             break;
     }
 }
@@ -3284,7 +3284,7 @@ Atone_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->mTwoPiOverSr = -TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, Atone_compute_next_data_frame);
-    self->mode_func_ptr = Atone_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Atone_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "mul", "add", NULL};
 
@@ -3485,44 +3485,44 @@ DCBlock_setProcMode(DCBlock *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = DCBlock_filters;
+    self->proc_func_ptr = (void (*)(void *))DCBlock_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = DCBlock_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = DCBlock_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = DCBlock_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = DCBlock_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = DCBlock_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = DCBlock_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = DCBlock_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = DCBlock_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = DCBlock_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))DCBlock_postprocessing_revareva;
             break;
     }
 }
@@ -3573,7 +3573,7 @@ DCBlock_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, DCBlock_compute_next_data_frame);
-    self->mode_func_ptr = DCBlock_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))DCBlock_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3956,58 +3956,58 @@ Allpass_setProcMode(Allpass *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Allpass_process_ii;
+            self->proc_func_ptr = (void (*)(void *))Allpass_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Allpass_process_ai;
+            self->proc_func_ptr = (void (*)(void *))Allpass_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Allpass_process_ia;
+            self->proc_func_ptr = (void (*)(void *))Allpass_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Allpass_process_aa;
+            self->proc_func_ptr = (void (*)(void *))Allpass_process_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Allpass_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Allpass_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Allpass_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Allpass_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Allpass_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Allpass_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Allpass_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Allpass_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Allpass_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass_postprocessing_revareva;
             break;
     }
 }
@@ -4068,7 +4068,7 @@ Allpass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Allpass_compute_next_data_frame);
-    self->mode_func_ptr = Allpass_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Allpass_setProcMode;
 
     static char *kwlist[] = {"input", "delay", "feedback", "maxDelay", "mul", "add", NULL};
 
@@ -4404,58 +4404,58 @@ Allpass2_setProcMode(Allpass2 *self)
     {
         case 0:
             Allpass2_compute_variables(self, PyFloat_AS_DOUBLE(self->freq), PyFloat_AS_DOUBLE(self->bw));
-            self->proc_func_ptr = Allpass2_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Allpass2_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Allpass2_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Allpass2_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Allpass2_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Allpass2_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Allpass2_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Allpass2_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Allpass2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Allpass2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Allpass2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Allpass2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Allpass2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Allpass2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Allpass2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Allpass2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Allpass2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Allpass2_postprocessing_revareva;
             break;
     }
 }
@@ -4519,7 +4519,7 @@ Allpass2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->nyquist = (MYFLT)self->sr * 0.49;
 
     Stream_setFunctionPtr(self->stream, Allpass2_compute_next_data_frame);
-    self->mode_func_ptr = Allpass2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Allpass2_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "bw", "mul", "add", NULL};
 
@@ -5189,74 +5189,74 @@ Phaser_setProcMode(Phaser *self)
     {
         case 0:
             Phaser_compute_variables(self, PyFloat_AS_DOUBLE(self->freq), PyFloat_AS_DOUBLE(self->spread), PyFloat_AS_DOUBLE(self->q));
-            self->proc_func_ptr = Phaser_filters_iii;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Phaser_filters_aii;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Phaser_filters_iai;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Phaser_filters_aai;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Phaser_filters_iia;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Phaser_filters_aia;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Phaser_filters_iaa;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Phaser_filters_aaa;
+            self->proc_func_ptr = (void (*)(void *))Phaser_filters_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Phaser_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Phaser_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Phaser_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Phaser_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Phaser_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Phaser_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Phaser_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Phaser_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Phaser_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Phaser_postprocessing_revareva;
             break;
     }
 }
@@ -5334,7 +5334,7 @@ Phaser_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->norm_arr_pos = 1.0 / PI * 512.0;
 
     Stream_setFunctionPtr(self->stream, Phaser_compute_next_data_frame);
-    self->mode_func_ptr = Phaser_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Phaser_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "spread", "q", "feedback", "num", "mul", "add", NULL};
 
@@ -6441,74 +6441,74 @@ Vocoder_setProcMode(Vocoder *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Vocoder_filters_iii;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Vocoder_filters_aii;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Vocoder_filters_iai;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Vocoder_filters_aai;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Vocoder_filters_iia;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Vocoder_filters_aia;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Vocoder_filters_iaa;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Vocoder_filters_aaa;
+            self->proc_func_ptr = (void (*)(void *))Vocoder_filters_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Vocoder_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Vocoder_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Vocoder_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Vocoder_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Vocoder_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Vocoder_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Vocoder_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Vocoder_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Vocoder_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Vocoder_postprocessing_revareva;
             break;
     }
 }
@@ -6595,7 +6595,7 @@ Vocoder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->twoPiOnSr = (MYFLT)(TWOPI / self->sr);
 
     Stream_setFunctionPtr(self->stream, Vocoder_compute_next_data_frame);
-    self->mode_func_ptr = Vocoder_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Vocoder_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "freq", "spread", "q", "slope", "stages", "mul", "add", NULL};
 
@@ -7281,74 +7281,74 @@ SVF_setProcMode(SVF *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SVF_filters_iii;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = SVF_filters_aii;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = SVF_filters_iai;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = SVF_filters_aai;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = SVF_filters_iia;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = SVF_filters_aia;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = SVF_filters_iaa;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = SVF_filters_aaa;
+            self->proc_func_ptr = (void (*)(void *))SVF_filters_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SVF_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SVF_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SVF_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SVF_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SVF_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SVF_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SVF_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SVF_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SVF_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SVF_postprocessing_revareva;
             break;
     }
 }
@@ -7416,7 +7416,7 @@ SVF_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->piOverSr = PI / self->sr;
 
     Stream_setFunctionPtr(self->stream, SVF_compute_next_data_frame);
-    self->mode_func_ptr = SVF_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SVF_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "type", "mul", "add", NULL};
 
@@ -8083,58 +8083,58 @@ SVF2_setProcMode(SVF2 *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SVF2_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))SVF2_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = SVF2_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))SVF2_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = SVF2_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))SVF2_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = SVF2_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))SVF2_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SVF2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SVF2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SVF2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SVF2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SVF2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SVF2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SVF2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SVF2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SVF2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SVF2_postprocessing_revareva;
             break;
     }
 }
@@ -8212,7 +8212,7 @@ SVF2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->oneOverSr = 1.0 / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, SVF2_compute_next_data_frame);
-    self->mode_func_ptr = SVF2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SVF2_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "shelf", "type", "mul", "add", NULL};
 
@@ -8508,44 +8508,44 @@ Average_setProcMode(Average *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Average_process_i;
+    self->proc_func_ptr = (void (*)(void *))Average_process_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Average_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Average_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Average_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Average_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Average_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Average_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Average_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Average_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Average_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Average_postprocessing_revareva;
             break;
     }
 }
@@ -8600,7 +8600,7 @@ Average_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Average_compute_next_data_frame);
-    self->mode_func_ptr = Average_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Average_setProcMode;
 
     static char *kwlist[] = {"input", "size", "mul", "add", NULL};
 
@@ -8963,58 +8963,58 @@ Reson_setProcMode(Reson *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Reson_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Reson_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Reson_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Reson_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Reson_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Reson_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Reson_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Reson_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Reson_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Reson_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Reson_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Reson_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Reson_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Reson_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Reson_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Reson_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Reson_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Reson_postprocessing_revareva;
             break;
     }
 }
@@ -9079,7 +9079,7 @@ Reson_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->twopiOverSr = TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, Reson_compute_next_data_frame);
-    self->mode_func_ptr = Reson_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Reson_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "mul", "add", NULL};
 
@@ -9471,58 +9471,58 @@ Resonx_setProcMode(Resonx *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Resonx_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))Resonx_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Resonx_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))Resonx_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Resonx_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))Resonx_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Resonx_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))Resonx_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Resonx_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Resonx_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Resonx_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Resonx_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Resonx_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Resonx_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Resonx_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Resonx_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Resonx_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Resonx_postprocessing_revareva;
             break;
     }
 }
@@ -9591,7 +9591,7 @@ Resonx_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->twopiOverSr = TWOPI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, Resonx_compute_next_data_frame);
-    self->mode_func_ptr = Resonx_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Resonx_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "stages", "mul", "add", NULL};
 
@@ -9893,50 +9893,50 @@ ButLP_setProcMode(ButLP *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ButLP_filters_i;
+            self->proc_func_ptr = (void (*)(void *))ButLP_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = ButLP_filters_a;
+            self->proc_func_ptr = (void (*)(void *))ButLP_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ButLP_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ButLP_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ButLP_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ButLP_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ButLP_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ButLP_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ButLP_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ButLP_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ButLP_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ButLP_postprocessing_revareva;
             break;
     }
 }
@@ -9997,7 +9997,7 @@ ButLP_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->sqrt2 = MYSQRT(2.0);
 
     Stream_setFunctionPtr(self->stream, ButLP_compute_next_data_frame);
-    self->mode_func_ptr = ButLP_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ButLP_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "mul", "add", NULL};
 
@@ -10274,50 +10274,50 @@ ButHP_setProcMode(ButHP *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ButHP_filters_i;
+            self->proc_func_ptr = (void (*)(void *))ButHP_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = ButHP_filters_a;
+            self->proc_func_ptr = (void (*)(void *))ButHP_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ButHP_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ButHP_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ButHP_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ButHP_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ButHP_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ButHP_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ButHP_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ButHP_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ButHP_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ButHP_postprocessing_revareva;
             break;
     }
 }
@@ -10378,7 +10378,7 @@ ButHP_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->sqrt2 = MYSQRT(2.0);
 
     Stream_setFunctionPtr(self->stream, ButHP_compute_next_data_frame);
-    self->mode_func_ptr = ButHP_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ButHP_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "mul", "add", NULL};
 
@@ -10720,58 +10720,58 @@ ButBP_setProcMode(ButBP *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ButBP_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))ButBP_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = ButBP_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))ButBP_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = ButBP_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))ButBP_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = ButBP_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))ButBP_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ButBP_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ButBP_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ButBP_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ButBP_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ButBP_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ButBP_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ButBP_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ButBP_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ButBP_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ButBP_postprocessing_revareva;
             break;
     }
 }
@@ -10836,7 +10836,7 @@ ButBP_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->piOnSr = PI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, ButBP_compute_next_data_frame);
-    self->mode_func_ptr = ButBP_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ButBP_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "mul", "add", NULL};
 
@@ -11186,58 +11186,58 @@ ButBR_setProcMode(ButBR *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ButBR_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))ButBR_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = ButBR_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))ButBR_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = ButBR_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))ButBR_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = ButBR_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))ButBR_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ButBR_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ButBR_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ButBR_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ButBR_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ButBR_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ButBR_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ButBR_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ButBR_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ButBR_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ButBR_postprocessing_revareva;
             break;
     }
 }
@@ -11302,7 +11302,7 @@ ButBR_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->piOnSr = PI / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, ButBR_compute_next_data_frame);
-    self->mode_func_ptr = ButBR_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ButBR_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "q", "mul", "add", NULL};
 
@@ -11660,58 +11660,58 @@ ComplexRes_setProcMode(ComplexRes *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ComplexRes_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))ComplexRes_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = ComplexRes_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))ComplexRes_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = ComplexRes_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))ComplexRes_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = ComplexRes_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))ComplexRes_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ComplexRes_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ComplexRes_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ComplexRes_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ComplexRes_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ComplexRes_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ComplexRes_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ComplexRes_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ComplexRes_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ComplexRes_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ComplexRes_postprocessing_revareva;
             break;
     }
 }
@@ -11777,7 +11777,7 @@ ComplexRes_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->oneOnSr = 1.0 / self->sr;
 
     Stream_setFunctionPtr(self->stream, ComplexRes_compute_next_data_frame);
-    self->mode_func_ptr = ComplexRes_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ComplexRes_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "decay", "mul", "add", NULL};
 
@@ -12154,58 +12154,58 @@ MoogLP_setProcMode(MoogLP *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = MoogLP_filters_ii;
+            self->proc_func_ptr = (void (*)(void *))MoogLP_filters_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = MoogLP_filters_ai;
+            self->proc_func_ptr = (void (*)(void *))MoogLP_filters_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = MoogLP_filters_ia;
+            self->proc_func_ptr = (void (*)(void *))MoogLP_filters_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = MoogLP_filters_aa;
+            self->proc_func_ptr = (void (*)(void *))MoogLP_filters_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MoogLP_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MoogLP_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MoogLP_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MoogLP_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MoogLP_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MoogLP_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MoogLP_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MoogLP_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MoogLP_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MoogLP_postprocessing_revareva;
             break;
     }
 }
@@ -12269,7 +12269,7 @@ MoogLP_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->oneOverSr = 1.0 / (MYFLT)self->sr;
 
     Stream_setFunctionPtr(self->stream, MoogLP_compute_next_data_frame);
-    self->mode_func_ptr = MoogLP_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MoogLP_setProcMode;
 
     static char *kwlist[] = {"input", "freq", "res", "mul", "add", NULL};
 

--- a/src/objects/freeverbmodule.c
+++ b/src/objects/freeverbmodule.c
@@ -583,74 +583,74 @@ Freeverb_setProcMode(Freeverb *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Freeverb_transform_iii;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Freeverb_transform_aii;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Freeverb_transform_iai;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Freeverb_transform_aai;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Freeverb_transform_iia;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Freeverb_transform_aia;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Freeverb_transform_iaa;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Freeverb_transform_aaa;
+            self->proc_func_ptr = (void (*)(void *))Freeverb_transform_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Freeverb_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Freeverb_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Freeverb_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Freeverb_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Freeverb_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Freeverb_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Freeverb_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Freeverb_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Freeverb_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Freeverb_postprocessing_revareva;
             break;
     }
 }
@@ -727,7 +727,7 @@ Freeverb_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Freeverb_compute_next_data_frame);
-    self->mode_func_ptr = Freeverb_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Freeverb_setProcMode;
 
     static char *kwlist[] = {"input", "size", "damp", "mix", "mul", "add", NULL};
 

--- a/src/objects/granulatormodule.c
+++ b/src/objects/granulatormodule.c
@@ -668,74 +668,74 @@ Granulator_setProcMode(Granulator *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Granulator_transform_iii;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Granulator_transform_aii;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Granulator_transform_iai;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Granulator_transform_aai;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Granulator_transform_iia;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Granulator_transform_aia;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Granulator_transform_iaa;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Granulator_transform_aaa;
+            self->proc_func_ptr = (void (*)(void *))Granulator_transform_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Granulator_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Granulator_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Granulator_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Granulator_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Granulator_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Granulator_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Granulator_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Granulator_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Granulator_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Granulator_postprocessing_revareva;
             break;
     }
 }
@@ -804,7 +804,7 @@ Granulator_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Granulator_compute_next_data_frame);
-    self->mode_func_ptr = Granulator_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Granulator_setProcMode;
 
     static char *kwlist[] = {"table", "env", "pitch", "pos", "dur", "grains", "basedur", "mul", "add", NULL};
 
@@ -1966,50 +1966,50 @@ Looper_setProcMode(Looper *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Looper_transform_i;
+            self->proc_func_ptr = (void (*)(void *))Looper_transform_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Looper_transform_a;
+            self->proc_func_ptr = (void (*)(void *))Looper_transform_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Looper_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Looper_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Looper_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Looper_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Looper_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Looper_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Looper_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Looper_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Looper_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Looper_postprocessing_revareva;
             break;
     }
 }
@@ -2094,7 +2094,7 @@ Looper_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Looper_compute_next_data_frame);
-    self->mode_func_ptr = Looper_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Looper_setProcMode;
 
     static char *kwlist[] = {"table", "pitch", "start", "dur", "xfade", "mode", "xfadeshape", "startfromloop", "interp", "autosmooth", "mul", "add", NULL};
 
@@ -2472,39 +2472,39 @@ LooperTimeStream_setProcMode(LooperTimeStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = LooperTimeStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))LooperTimeStream_postprocessing_revareva;
             break;
     }
 }
@@ -2562,7 +2562,7 @@ LooperTimeStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, LooperTimeStream_compute_next_data_frame);
-    self->mode_func_ptr = LooperTimeStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))LooperTimeStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", NULL};
 
@@ -2986,50 +2986,50 @@ Granule_setProcMode(Granule *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Granule_transform_i;
+            self->proc_func_ptr = (void (*)(void *))Granule_transform_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Granule_transform_a;
+            self->proc_func_ptr = (void (*)(void *))Granule_transform_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Granule_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Granule_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Granule_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Granule_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Granule_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Granule_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Granule_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Granule_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Granule_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Granule_postprocessing_revareva;
             break;
     }
 }
@@ -3105,7 +3105,7 @@ Granule_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->srOnRandMax = self->sr / (MYFLT)PYO_RAND_MAX;
 
     Stream_setFunctionPtr(self->stream, Granule_compute_next_data_frame);
-    self->mode_func_ptr = Granule_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Granule_setProcMode;
 
     static char *kwlist[] = {"table", "env", "dens", "pitch", "pos", "dur", "mul", "add", NULL};
 
@@ -4017,17 +4017,17 @@ MainParticle_setProcMode(MainParticle *self)
     {
         case 0:
             if (self->chnls == 1)
-                self->proc_func_ptr = MainParticle_transform_mono_i;
+                self->proc_func_ptr = (void (*)(void *))MainParticle_transform_mono_i;
             else
-                self->proc_func_ptr = MainParticle_transform_i;
+                self->proc_func_ptr = (void (*)(void *))MainParticle_transform_i;
 
             break;
 
         case 1:
             if (self->chnls == 1)
-                self->proc_func_ptr = MainParticle_transform_mono_a;
+                self->proc_func_ptr = (void (*)(void *))MainParticle_transform_mono_a;
             else
-                self->proc_func_ptr = MainParticle_transform_a;
+                self->proc_func_ptr = (void (*)(void *))MainParticle_transform_a;
 
             break;
     }
@@ -4121,7 +4121,7 @@ MainParticle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->srOnRandMax = self->sr / (MYFLT)PYO_RAND_MAX;
 
     Stream_setFunctionPtr(self->stream, MainParticle_compute_next_data_frame);
-    self->mode_func_ptr = MainParticle_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MainParticle_setProcMode;
 
     static char *kwlist[] = {"table", "env", "dens", "pitch", "pos", "dur", "dev", "pan", "chnls", NULL};
 
@@ -4363,39 +4363,39 @@ Particle_setProcMode(Particle *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Particle_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Particle_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Particle_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Particle_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Particle_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Particle_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Particle_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Particle_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Particle_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Particle_postprocessing_revareva;
             break;
     }
 }
@@ -4454,7 +4454,7 @@ Particle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Particle_compute_next_data_frame);
-    self->mode_func_ptr = Particle_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Particle_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -5588,17 +5588,17 @@ MainParticle2_setProcMode(MainParticle2 *self)
     {
         case 0:
             if (self->chnls == 1)
-                self->proc_func_ptr = MainParticle2_transform_mono_i;
+                self->proc_func_ptr = (void (*)(void *))MainParticle2_transform_mono_i;
             else
-                self->proc_func_ptr = MainParticle2_transform_i;
+                self->proc_func_ptr = (void (*)(void *))MainParticle2_transform_i;
 
             break;
 
         case 1:
             if (self->chnls == 1)
-                self->proc_func_ptr = MainParticle2_transform_mono_a;
+                self->proc_func_ptr = (void (*)(void *))MainParticle2_transform_mono_a;
             else
-                self->proc_func_ptr = MainParticle2_transform_a;
+                self->proc_func_ptr = (void (*)(void *))MainParticle2_transform_a;
 
             break;
     }
@@ -5725,7 +5725,7 @@ MainParticle2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->filterfreq = PyFloat_FromDouble(self->nyquist);
 
     Stream_setFunctionPtr(self->stream, MainParticle2_compute_next_data_frame);
-    self->mode_func_ptr = MainParticle2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MainParticle2_setProcMode;
 
     static char *kwlist[] = {"table", "env", "dens", "pitch", "pos", "dur", "dev", "pan", "filterfreq", "filterq", "filtertype", "chnls", NULL};
 
@@ -6012,39 +6012,39 @@ Particle2_setProcMode(Particle2 *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Particle2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Particle2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Particle2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Particle2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Particle2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Particle2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Particle2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Particle2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Particle2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Particle2_postprocessing_revareva;
             break;
     }
 }
@@ -6103,7 +6103,7 @@ Particle2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Particle2_compute_next_data_frame);
-    self->mode_func_ptr = Particle2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Particle2_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 

--- a/src/objects/harmonizermodule.c
+++ b/src/objects/harmonizermodule.c
@@ -410,58 +410,58 @@ Harmonizer_setProcMode(Harmonizer *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Harmonizer_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Harmonizer_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Harmonizer_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Harmonizer_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Harmonizer_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Harmonizer_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Harmonizer_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Harmonizer_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Harmonizer_feedbacktprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Harmonizer_feedbacktprocessing_revareva;
             break;
     }
 }
@@ -525,7 +525,7 @@ Harmonizer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Harmonizer_compute_next_data_frame);
-    self->mode_func_ptr = Harmonizer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Harmonizer_setProcMode;
 
     static char *kwlist[] = {"input", "transpo", "feedback", "winsize", "mul", "add", NULL};
 

--- a/src/objects/hilbertmodule.c
+++ b/src/objects/hilbertmodule.c
@@ -104,7 +104,7 @@ HilbertMain_getSamplesBuffer(HilbertMain *self)
 static void
 HilbertMain_setProcMode(HilbertMain *self)
 {
-    self->proc_func_ptr = HilbertMain_filters;
+    self->proc_func_ptr = (void (*)(void *))HilbertMain_filters;
 }
 
 static void
@@ -149,7 +149,7 @@ HilbertMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, HilbertMain_compute_next_data_frame);
-    self->mode_func_ptr = HilbertMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))HilbertMain_setProcMode;
 
     for (i = 0; i < 12; i++)
     {
@@ -270,39 +270,39 @@ Hilbert_setProcMode(Hilbert *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Hilbert_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Hilbert_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Hilbert_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Hilbert_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Hilbert_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Hilbert_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Hilbert_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Hilbert_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Hilbert_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Hilbert_postprocessing_revareva;
             break;
     }
 }
@@ -361,7 +361,7 @@ Hilbert_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Hilbert_compute_next_data_frame);
-    self->mode_func_ptr = Hilbert_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Hilbert_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 

--- a/src/objects/hrtfmodule.c
+++ b/src/objects/hrtfmodule.c
@@ -596,7 +596,7 @@ HRTFSpatter_getSamplesBuffer(HRTFSpatter *self)
 static void
 HRTFSpatter_setProcMode(HRTFSpatter *self)
 {
-    self->proc_func_ptr = HRTFSpatter_splitter;
+    self->proc_func_ptr = (void (*)(void *))HRTFSpatter_splitter;
 }
 
 static void
@@ -665,7 +665,7 @@ HRTFSpatter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, HRTFSpatter_compute_next_data_frame);
-    self->mode_func_ptr = HRTFSpatter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))HRTFSpatter_setProcMode;
 
     self->azi = PyFloat_FromDouble(0.0);
     self->ele = PyFloat_FromDouble(0.0);
@@ -843,39 +843,39 @@ HRTF_setProcMode(HRTF *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = HRTF_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = HRTF_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = HRTF_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = HRTF_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = HRTF_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = HRTF_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = HRTF_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = HRTF_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = HRTF_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))HRTF_postprocessing_revareva;
             break;
     }
 }
@@ -934,7 +934,7 @@ HRTF_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, HRTF_compute_next_data_frame);
-    self->mode_func_ptr = HRTF_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))HRTF_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -1259,7 +1259,7 @@ Binauraler_getSamplesBuffer(Binauraler *self)
 static void
 Binauraler_setProcMode(Binauraler *self)
 {
-    self->proc_func_ptr = Binauraler_splitter;
+    self->proc_func_ptr = (void (*)(void *))Binauraler_splitter;
 }
 
 static void
@@ -1321,7 +1321,7 @@ Binauraler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Binauraler_compute_next_data_frame);
-    self->mode_func_ptr = Binauraler_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Binauraler_setProcMode;
 
     self->azi = PyFloat_FromDouble(0.0);
     self->ele = PyFloat_FromDouble(0.0);
@@ -1553,39 +1553,39 @@ Binaural_setProcMode(Binaural *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Binaural_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Binaural_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Binaural_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Binaural_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Binaural_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Binaural_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Binaural_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Binaural_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Binaural_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Binaural_postprocessing_revareva;
             break;
     }
 }
@@ -1644,7 +1644,7 @@ Binaural_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Binaural_compute_next_data_frame);
-    self->mode_func_ptr = Binaural_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Binaural_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 

--- a/src/objects/inputmodule.c
+++ b/src/objects/inputmodule.c
@@ -51,39 +51,39 @@ Input_setProcMode(Input *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Input_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Input_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Input_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Input_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Input_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Input_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Input_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Input_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Input_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Input_postprocessing_revareva;
             break;
     }
 }
@@ -141,7 +141,7 @@ Input_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Input_compute_next_data_frame);
-    self->mode_func_ptr = Input_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Input_setProcMode;
 
     static char *kwlist[] = {"chnl", "mul", "add", NULL};
 

--- a/src/objects/lfomodule.c
+++ b/src/objects/lfomodule.c
@@ -1249,58 +1249,58 @@ LFO_setProcMode(LFO *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = LFO_generates_ii;
+            self->proc_func_ptr = (void (*)(void *))LFO_generates_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = LFO_generates_ai;
+            self->proc_func_ptr = (void (*)(void *))LFO_generates_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = LFO_generates_ia;
+            self->proc_func_ptr = (void (*)(void *))LFO_generates_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = LFO_generates_aa;
+            self->proc_func_ptr = (void (*)(void *))LFO_generates_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = LFO_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = LFO_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = LFO_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = LFO_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = LFO_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = LFO_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = LFO_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = LFO_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = LFO_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))LFO_postprocessing_revareva;
             break;
     }
 }
@@ -1365,7 +1365,7 @@ LFO_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->srOverFour = (MYFLT)self->sr * 0.25;
     self->srOverEight = (MYFLT)self->sr * 0.125;
     Stream_setFunctionPtr(self->stream, LFO_compute_next_data_frame);
-    self->mode_func_ptr = LFO_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))LFO_setProcMode;
 
     static char *kwlist[] = {"freq", "sharp", "type", "mul", "add", NULL};
 

--- a/src/objects/matrixprocessmodule.c
+++ b/src/objects/matrixprocessmodule.c
@@ -70,44 +70,44 @@ MatrixPointer_setProcMode(MatrixPointer *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MatrixPointer_readframes;
+    self->proc_func_ptr = (void (*)(void *))MatrixPointer_readframes;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MatrixPointer_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MatrixPointer_postprocessing_revareva;
             break;
     }
 }
@@ -164,7 +164,7 @@ MatrixPointer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MatrixPointer_compute_next_data_frame);
-    self->mode_func_ptr = MatrixPointer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MatrixPointer_setProcMode;
 
     static char *kwlist[] = {"matrix", "x", "y", "mul", "add", NULL};
 

--- a/src/objects/metromodule.c
+++ b/src/objects/metromodule.c
@@ -124,50 +124,50 @@ Metro_setProcMode(Metro *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Metro_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Metro_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Metro_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Metro_generate_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Metro_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Metro_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Metro_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Metro_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Metro_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Metro_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Metro_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Metro_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Metro_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Metro_postprocessing_revareva;
             break;
     }
 }
@@ -220,7 +220,7 @@ Metro_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Metro_compute_next_data_frame);
-    self->mode_func_ptr = Metro_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Metro_setProcMode;
 
     Stream_setStreamActive(self->stream, 0);
 
@@ -640,19 +640,19 @@ Seqer_setProcMode(Seqer *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Seqer_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))Seqer_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Seqer_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))Seqer_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Seqer_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))Seqer_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Seqer_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))Seqer_generate_aa;
             break;
     }
 }
@@ -718,7 +718,7 @@ Seqer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Seqer_compute_next_data_frame);
-    self->mode_func_ptr = Seqer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Seqer_setProcMode;
 
     Stream_setStreamActive(self->stream, 0);
 
@@ -895,39 +895,39 @@ Seq_setProcMode(Seq *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Seq_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Seq_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Seq_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Seq_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Seq_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Seq_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Seq_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Seq_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Seq_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Seq_postprocessing_revareva;
             break;
     }
 }
@@ -987,7 +987,7 @@ Seq_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Seq_compute_next_data_frame);
-    self->mode_func_ptr = Seq_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Seq_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -1225,11 +1225,11 @@ Clouder_setProcMode(Clouder *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Clouder_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Clouder_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Clouder_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Clouder_generate_a;
             break;
     }
 }
@@ -1281,7 +1281,7 @@ Clouder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Clouder_compute_next_data_frame);
-    self->mode_func_ptr = Clouder_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Clouder_setProcMode;
 
     Stream_setStreamActive(self->stream, 0);
 
@@ -1404,39 +1404,39 @@ Cloud_setProcMode(Cloud *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Cloud_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Cloud_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Cloud_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Cloud_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Cloud_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Cloud_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Cloud_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Cloud_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Cloud_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Cloud_postprocessing_revareva;
             break;
     }
 }
@@ -1496,7 +1496,7 @@ Cloud_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Cloud_compute_next_data_frame);
-    self->mode_func_ptr = Cloud_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Cloud_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -1665,39 +1665,39 @@ Trig_setProcMode(Trig *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Trig_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Trig_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Trig_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Trig_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Trig_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Trig_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Trig_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Trig_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Trig_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Trig_postprocessing_revareva;
             break;
     }
 }
@@ -1752,7 +1752,7 @@ Trig_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Trig_compute_next_data_frame);
-    self->mode_func_ptr = Trig_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Trig_setProcMode;
 
     static char *kwlist[] = {NULL};
 
@@ -2443,11 +2443,11 @@ Beater_setProcMode(Beater *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Beater_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Beater_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Beater_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Beater_generate_a;
             break;
     }
 }
@@ -2526,7 +2526,7 @@ Beater_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Beater_compute_next_data_frame);
-    self->mode_func_ptr = Beater_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Beater_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
     self->currentTime = -1.0;
@@ -2867,39 +2867,39 @@ Beat_setProcMode(Beat *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Beat_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Beat_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Beat_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Beat_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Beat_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Beat_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Beat_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Beat_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Beat_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Beat_postprocessing_revareva;
             break;
     }
 }
@@ -2959,7 +2959,7 @@ Beat_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Beat_compute_next_data_frame);
-    self->mode_func_ptr = Beat_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Beat_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -3129,39 +3129,39 @@ BeatTapStream_setProcMode(BeatTapStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BeatTapStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BeatTapStream_postprocessing_revareva;
             break;
     }
 }
@@ -3221,7 +3221,7 @@ BeatTapStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BeatTapStream_compute_next_data_frame);
-    self->mode_func_ptr = BeatTapStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BeatTapStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -3391,39 +3391,39 @@ BeatAmpStream_setProcMode(BeatAmpStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BeatAmpStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BeatAmpStream_postprocessing_revareva;
             break;
     }
 }
@@ -3483,7 +3483,7 @@ BeatAmpStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BeatAmpStream_compute_next_data_frame);
-    self->mode_func_ptr = BeatAmpStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BeatAmpStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -3653,39 +3653,39 @@ BeatDurStream_setProcMode(BeatDurStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BeatDurStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BeatDurStream_postprocessing_revareva;
             break;
     }
 }
@@ -3745,7 +3745,7 @@ BeatDurStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BeatDurStream_compute_next_data_frame);
-    self->mode_func_ptr = BeatDurStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BeatDurStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -3915,39 +3915,39 @@ BeatEndStream_setProcMode(BeatEndStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BeatEndStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BeatEndStream_postprocessing_revareva;
             break;
     }
 }
@@ -4007,7 +4007,7 @@ BeatEndStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BeatEndStream_compute_next_data_frame);
-    self->mode_func_ptr = BeatEndStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BeatEndStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -4274,7 +4274,7 @@ TrigBurster_getEndBuffer(TrigBurster *self)
 static void
 TrigBurster_setProcMode(TrigBurster *self)
 {
-    self->proc_func_ptr = TrigBurster_generate_i;
+    self->proc_func_ptr = (void (*)(void *))TrigBurster_generate_i;
 }
 
 static void
@@ -4338,7 +4338,7 @@ TrigBurster_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurster_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurster_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurster_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -4526,39 +4526,39 @@ TrigBurst_setProcMode(TrigBurst *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigBurst_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigBurst_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigBurst_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigBurst_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigBurst_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigBurst_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigBurst_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigBurst_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigBurst_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurst_postprocessing_revareva;
             break;
     }
 }
@@ -4618,7 +4618,7 @@ TrigBurst_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurst_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurst_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurst_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -4788,39 +4788,39 @@ TrigBurstTapStream_setProcMode(TrigBurstTapStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigBurstTapStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstTapStream_postprocessing_revareva;
             break;
     }
 }
@@ -4880,7 +4880,7 @@ TrigBurstTapStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurstTapStream_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurstTapStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurstTapStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -5050,39 +5050,39 @@ TrigBurstAmpStream_setProcMode(TrigBurstAmpStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigBurstAmpStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstAmpStream_postprocessing_revareva;
             break;
     }
 }
@@ -5142,7 +5142,7 @@ TrigBurstAmpStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurstAmpStream_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurstAmpStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurstAmpStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -5312,39 +5312,39 @@ TrigBurstDurStream_setProcMode(TrigBurstDurStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigBurstDurStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstDurStream_postprocessing_revareva;
             break;
     }
 }
@@ -5404,7 +5404,7 @@ TrigBurstDurStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurstDurStream_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurstDurStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurstDurStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -5574,39 +5574,39 @@ TrigBurstEndStream_setProcMode(TrigBurstEndStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigBurstEndStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigBurstEndStream_postprocessing_revareva;
             break;
     }
 }
@@ -5666,7 +5666,7 @@ TrigBurstEndStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigBurstEndStream_compute_next_data_frame);
-    self->mode_func_ptr = TrigBurstEndStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigBurstEndStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 

--- a/src/objects/midimodule.c
+++ b/src/objects/midimodule.c
@@ -111,7 +111,7 @@ CtlScan_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CtlScan_compute_next_data_frame);
-    self->mode_func_ptr = CtlScan_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CtlScan_setProcMode;
 
     static char *kwlist[] = {"callable", "toprint", NULL};
 
@@ -318,7 +318,7 @@ CtlScan2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CtlScan2_compute_next_data_frame);
-    self->mode_func_ptr = CtlScan2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CtlScan2_setProcMode;
 
     static char *kwlist[] = {"callable", "toprint", NULL};
 
@@ -495,39 +495,39 @@ Midictl_setProcMode(Midictl *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Midictl_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Midictl_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Midictl_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Midictl_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Midictl_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Midictl_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Midictl_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Midictl_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Midictl_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Midictl_postprocessing_revareva;
             break;
     }
 }
@@ -648,7 +648,7 @@ Midictl_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Midictl_compute_next_data_frame);
-    self->mode_func_ptr = Midictl_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Midictl_setProcMode;
 
     static char *kwlist[] = {"ctlnumber", "minscale", "maxscale", "init", "channel", "mul", "add", NULL};
 
@@ -902,39 +902,39 @@ Bendin_setProcMode(Bendin *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Bendin_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Bendin_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Bendin_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Bendin_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Bendin_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Bendin_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Bendin_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Bendin_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Bendin_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Bendin_postprocessing_revareva;
             break;
     }
 }
@@ -1063,7 +1063,7 @@ Bendin_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Bendin_compute_next_data_frame);
-    self->mode_func_ptr = Bendin_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Bendin_setProcMode;
 
     static char *kwlist[] = {"brange", "scale", "channel", "mul", "add", NULL};
 
@@ -1299,39 +1299,39 @@ Touchin_setProcMode(Touchin *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Touchin_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Touchin_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Touchin_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Touchin_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Touchin_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Touchin_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Touchin_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Touchin_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Touchin_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Touchin_postprocessing_revareva;
             break;
     }
 }
@@ -1451,7 +1451,7 @@ Touchin_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Touchin_compute_next_data_frame);
-    self->mode_func_ptr = Touchin_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Touchin_setProcMode;
 
     static char *kwlist[] = {"minscale", "maxscale", "init", "channel", "mul", "add", NULL};
 
@@ -1670,39 +1670,39 @@ Programin_setProcMode(Programin *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Programin_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Programin_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Programin_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Programin_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Programin_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Programin_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Programin_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Programin_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Programin_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Programin_postprocessing_revareva;
             break;
     }
 }
@@ -1798,7 +1798,7 @@ Programin_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Programin_compute_next_data_frame);
-    self->mode_func_ptr = Programin_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Programin_setProcMode;
 
     static char *kwlist[] = {"channel", "mul", "add", NULL};
 
@@ -2248,7 +2248,7 @@ MidiNote_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MidiNote_compute_next_data_frame);
-    self->mode_func_ptr = MidiNote_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MidiNote_setProcMode;
 
     static char *kwlist[] = {"voices", "scale", "first", "last", "channel", NULL};
 
@@ -2611,39 +2611,39 @@ Notein_setProcMode(Notein *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Notein_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Notein_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Notein_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Notein_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Notein_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Notein_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Notein_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Notein_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Notein_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Notein_postprocessing_revareva;
             break;
     }
 }
@@ -2747,7 +2747,7 @@ Notein_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Notein_compute_next_data_frame);
-    self->mode_func_ptr = Notein_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Notein_setProcMode;
 
     static char *kwlist[] = {"handler", "voice", "mode", "mul", "add", NULL};
 
@@ -2925,39 +2925,39 @@ NoteinTrig_setProcMode(NoteinTrig *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = NoteinTrig_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinTrig_postprocessing_revareva;
             break;
     }
 }
@@ -3016,7 +3016,7 @@ NoteinTrig_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, NoteinTrig_compute_next_data_frame);
-    self->mode_func_ptr = NoteinTrig_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))NoteinTrig_setProcMode;
 
     static char *kwlist[] = {"handler", "voice", "mode", "mul", "add", NULL};
 
@@ -3280,44 +3280,44 @@ MidiAdsr_setProcMode(MidiAdsr *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MidiAdsr_generates;
+    self->proc_func_ptr = (void (*)(void *))MidiAdsr_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MidiAdsr_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MidiAdsr_postprocessing_revareva;
             break;
     }
 }
@@ -3377,7 +3377,7 @@ MidiAdsr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MidiAdsr_compute_next_data_frame);
-    self->mode_func_ptr = MidiAdsr_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MidiAdsr_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -3753,44 +3753,44 @@ MidiDelAdsr_setProcMode(MidiDelAdsr *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MidiDelAdsr_generates;
+    self->proc_func_ptr = (void (*)(void *))MidiDelAdsr_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MidiDelAdsr_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MidiDelAdsr_postprocessing_revareva;
             break;
     }
 }
@@ -3851,7 +3851,7 @@ MidiDelAdsr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MidiDelAdsr_compute_next_data_frame);
-    self->mode_func_ptr = MidiDelAdsr_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MidiDelAdsr_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -4193,7 +4193,7 @@ RawMidi_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RawMidi_compute_next_data_frame);
-    self->mode_func_ptr = RawMidi_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RawMidi_setProcMode;
 
     static char *kwlist[] = {"callable", NULL};
 
@@ -4472,44 +4472,44 @@ MidiLinseg_setProcMode(MidiLinseg *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MidiLinseg_generate;
+    self->proc_func_ptr = (void (*)(void *))MidiLinseg_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MidiLinseg_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MidiLinseg_postprocessing_revareva;
             break;
     }
 }
@@ -4569,7 +4569,7 @@ MidiLinseg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MidiLinseg_compute_next_data_frame);
-    self->mode_func_ptr = MidiLinseg_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MidiLinseg_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 

--- a/src/objects/mmlmodule.c
+++ b/src/objects/mmlmodule.c
@@ -708,7 +708,7 @@ MMLMain_getZBuffer(MMLMain *self)
 static void
 MMLMain_setProcMode(MMLMain *self)
 {
-    self->proc_func_ptr = MMLMain_generate;
+    self->proc_func_ptr = (void (*)(void *))MMLMain_generate;
 }
 
 static void
@@ -788,7 +788,7 @@ MMLMain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLMain_compute_next_data_frame);
-    self->mode_func_ptr = MMLMain_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLMain_setProcMode;
 
     Stream_setStreamActive(self->stream, 0);
 
@@ -1015,39 +1015,39 @@ MML_setProcMode(MML *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MML_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MML_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MML_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MML_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MML_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MML_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MML_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MML_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MML_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MML_postprocessing_revareva;
             break;
     }
 }
@@ -1107,7 +1107,7 @@ MML_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MML_compute_next_data_frame);
-    self->mode_func_ptr = MML_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MML_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -1277,39 +1277,39 @@ MMLFreqStream_setProcMode(MMLFreqStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLFreqStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLFreqStream_postprocessing_revareva;
             break;
     }
 }
@@ -1369,7 +1369,7 @@ MMLFreqStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLFreqStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLFreqStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLFreqStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -1539,39 +1539,39 @@ MMLAmpStream_setProcMode(MMLAmpStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLAmpStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLAmpStream_postprocessing_revareva;
             break;
     }
 }
@@ -1631,7 +1631,7 @@ MMLAmpStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLAmpStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLAmpStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLAmpStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -1801,39 +1801,39 @@ MMLDurStream_setProcMode(MMLDurStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLDurStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLDurStream_postprocessing_revareva;
             break;
     }
 }
@@ -1893,7 +1893,7 @@ MMLDurStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLDurStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLDurStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLDurStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -2063,39 +2063,39 @@ MMLEndStream_setProcMode(MMLEndStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLEndStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLEndStream_postprocessing_revareva;
             break;
     }
 }
@@ -2155,7 +2155,7 @@ MMLEndStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLEndStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLEndStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLEndStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -2325,39 +2325,39 @@ MMLXStream_setProcMode(MMLXStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLXStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLXStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLXStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLXStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLXStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLXStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLXStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLXStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLXStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLXStream_postprocessing_revareva;
             break;
     }
 }
@@ -2417,7 +2417,7 @@ MMLXStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLXStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLXStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLXStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -2587,39 +2587,39 @@ MMLYStream_setProcMode(MMLYStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLYStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLYStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLYStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLYStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLYStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLYStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLYStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLYStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLYStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLYStream_postprocessing_revareva;
             break;
     }
 }
@@ -2679,7 +2679,7 @@ MMLYStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLYStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLYStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLYStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 
@@ -2849,39 +2849,39 @@ MMLZStream_setProcMode(MMLZStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MMLZStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MMLZStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MMLZStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MMLZStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MMLZStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MMLZStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MMLZStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MMLZStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MMLZStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MMLZStream_postprocessing_revareva;
             break;
     }
 }
@@ -2941,7 +2941,7 @@ MMLZStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MMLZStream_compute_next_data_frame);
-    self->mode_func_ptr = MMLZStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MMLZStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", NULL};
 

--- a/src/objects/noisemodule.c
+++ b/src/objects/noisemodule.c
@@ -75,50 +75,50 @@ Noise_setProcMode(Noise *self)
     switch (self->type)
     {
         case 0:
-            self->proc_func_ptr = Noise_generate;
+            self->proc_func_ptr = (void (*)(void *))Noise_generate;
             break;
 
         case 1:
-            self->proc_func_ptr = Noise_generate_cheap;
+            self->proc_func_ptr = (void (*)(void *))Noise_generate_cheap;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Noise_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Noise_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Noise_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Noise_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Noise_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Noise_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Noise_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Noise_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Noise_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Noise_postprocessing_revareva;
             break;
     }
 }
@@ -167,7 +167,7 @@ Noise_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Noise_compute_next_data_frame);
-    self->mode_func_ptr = Noise_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Noise_setProcMode;
 
     static char *kwlist[] = {"mul", "add", NULL};
 
@@ -387,39 +387,39 @@ PinkNoise_setProcMode(PinkNoise *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = PinkNoise_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = PinkNoise_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = PinkNoise_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = PinkNoise_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = PinkNoise_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = PinkNoise_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = PinkNoise_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = PinkNoise_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = PinkNoise_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))PinkNoise_postprocessing_revareva;
             break;
     }
 }
@@ -468,7 +468,7 @@ PinkNoise_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PinkNoise_compute_next_data_frame);
-    self->mode_func_ptr = PinkNoise_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PinkNoise_setProcMode;
 
     static char *kwlist[] = {"mul", "add", NULL};
 
@@ -658,39 +658,39 @@ BrownNoise_setProcMode(BrownNoise *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = BrownNoise_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = BrownNoise_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = BrownNoise_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = BrownNoise_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = BrownNoise_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = BrownNoise_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = BrownNoise_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = BrownNoise_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = BrownNoise_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))BrownNoise_postprocessing_revareva;
             break;
     }
 }
@@ -740,7 +740,7 @@ BrownNoise_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, BrownNoise_compute_next_data_frame);
-    self->mode_func_ptr = BrownNoise_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))BrownNoise_setProcMode;
 
     static char *kwlist[] = {"mul", "add", NULL};
 

--- a/src/objects/oscbankmodule.c
+++ b/src/objects/oscbankmodule.c
@@ -374,44 +374,44 @@ OscBank_setProcMode(OscBank *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = OscBank_readframes;
+    self->proc_func_ptr = (void (*)(void *))OscBank_readframes;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = OscBank_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = OscBank_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = OscBank_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = OscBank_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = OscBank_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = OscBank_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = OscBank_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = OscBank_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = OscBank_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))OscBank_postprocessing_revareva;
             break;
     }
 }
@@ -504,7 +504,7 @@ OscBank_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     INIT_OBJECT_COMMON
 
     Stream_setFunctionPtr(self->stream, OscBank_compute_next_data_frame);
-    self->mode_func_ptr = OscBank_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))OscBank_setProcMode;
 
     static char *kwlist[] = {"table", "freq", "spread", "slope", "frndf", "frnda", "arndf", "arnda", "num", "fjit", "mul", "add", NULL};
 

--- a/src/objects/oscilmodule.c
+++ b/src/objects/oscilmodule.c
@@ -199,58 +199,58 @@ Sine_setProcMode(Sine *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Sine_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Sine_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Sine_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Sine_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Sine_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Sine_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Sine_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Sine_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Sine_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Sine_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Sine_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Sine_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Sine_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Sine_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Sine_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Sine_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Sine_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Sine_postprocessing_revareva;
             break;
     }
 }
@@ -308,7 +308,7 @@ Sine_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Sine_compute_next_data_frame);
-    self->mode_func_ptr = Sine_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Sine_setProcMode;
 
     static char *kwlist[] = {"freq", "phase", "mul", "add", NULL};
 
@@ -719,17 +719,17 @@ FastSine_setProcMode(FastSine *self)
     {
         case 0:
             if (self->quality == 0)
-                self->proc_func_ptr = FastSine_readframes_low_i;
+                self->proc_func_ptr = (void (*)(void *))FastSine_readframes_low_i;
             else if (self->quality == 1)
-                self->proc_func_ptr = FastSine_readframes_high_i;
+                self->proc_func_ptr = (void (*)(void *))FastSine_readframes_high_i;
 
             break;
 
         case 1:
             if (self->quality == 0)
-                self->proc_func_ptr = FastSine_readframes_low_a;
+                self->proc_func_ptr = (void (*)(void *))FastSine_readframes_low_a;
             else if (self->quality == 1)
-                self->proc_func_ptr = FastSine_readframes_high_a;
+                self->proc_func_ptr = (void (*)(void *))FastSine_readframes_high_a;
 
             break;
     }
@@ -737,39 +737,39 @@ FastSine_setProcMode(FastSine *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FastSine_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FastSine_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FastSine_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FastSine_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FastSine_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FastSine_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FastSine_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FastSine_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FastSine_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FastSine_postprocessing_revareva;
             break;
     }
 }
@@ -824,7 +824,7 @@ FastSine_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FastSine_compute_next_data_frame);
-    self->mode_func_ptr = FastSine_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FastSine_setProcMode;
 
     self->twoPiOnSr = TWOPI / self->sr;
     self->B = 4.0 / PI;
@@ -1146,58 +1146,58 @@ SineLoop_setProcMode(SineLoop *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SineLoop_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))SineLoop_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = SineLoop_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))SineLoop_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = SineLoop_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))SineLoop_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = SineLoop_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))SineLoop_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SineLoop_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SineLoop_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SineLoop_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SineLoop_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SineLoop_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SineLoop_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SineLoop_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SineLoop_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SineLoop_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SineLoop_postprocessing_revareva;
             break;
     }
 }
@@ -1254,7 +1254,7 @@ SineLoop_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SineLoop_compute_next_data_frame);
-    self->mode_func_ptr = SineLoop_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SineLoop_setProcMode;
 
     static char *kwlist[] = {"freq", "feedback", "mul", "add", NULL};
 
@@ -1595,58 +1595,58 @@ Osc_setProcMode(Osc *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Osc_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Osc_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Osc_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Osc_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Osc_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Osc_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Osc_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Osc_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Osc_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Osc_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Osc_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Osc_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Osc_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Osc_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Osc_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Osc_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Osc_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Osc_postprocessing_revareva;
             break;
     }
 }
@@ -1704,7 +1704,7 @@ Osc_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Osc_compute_next_data_frame);
-    self->mode_func_ptr = Osc_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Osc_setProcMode;
 
     static char *kwlist[] = {"table", "freq", "phase", "interp", "mul", "add", NULL};
 
@@ -2081,58 +2081,58 @@ OscLoop_setProcMode(OscLoop *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = OscLoop_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))OscLoop_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = OscLoop_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))OscLoop_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = OscLoop_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))OscLoop_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = OscLoop_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))OscLoop_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = OscLoop_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = OscLoop_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = OscLoop_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = OscLoop_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = OscLoop_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = OscLoop_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = OscLoop_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = OscLoop_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = OscLoop_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))OscLoop_postprocessing_revareva;
             break;
     }
 }
@@ -2189,7 +2189,7 @@ OscLoop_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, OscLoop_compute_next_data_frame);
-    self->mode_func_ptr = OscLoop_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))OscLoop_setProcMode;
 
     static char *kwlist[] = {"table", "freq", "feedback", "mul", "add", NULL};
 
@@ -2574,58 +2574,58 @@ OscTrig_setProcMode(OscTrig *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = OscTrig_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))OscTrig_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = OscTrig_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))OscTrig_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = OscTrig_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))OscTrig_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = OscTrig_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))OscTrig_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = OscTrig_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = OscTrig_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = OscTrig_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = OscTrig_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = OscTrig_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = OscTrig_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = OscTrig_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = OscTrig_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = OscTrig_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))OscTrig_postprocessing_revareva;
             break;
     }
 }
@@ -2686,7 +2686,7 @@ OscTrig_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, OscTrig_compute_next_data_frame);
-    self->mode_func_ptr = OscTrig_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))OscTrig_setProcMode;
 
     static char *kwlist[] = {"table", "trig", "freq", "phase", "interp", "mul", "add", NULL};
 
@@ -3093,58 +3093,58 @@ Phasor_setProcMode(Phasor *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Phasor_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Phasor_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Phasor_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Phasor_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Phasor_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Phasor_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Phasor_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Phasor_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Phasor_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Phasor_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Phasor_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Phasor_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Phasor_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Phasor_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Phasor_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Phasor_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Phasor_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Phasor_postprocessing_revareva;
             break;
     }
 }
@@ -3201,7 +3201,7 @@ Phasor_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Phasor_compute_next_data_frame);
-    self->mode_func_ptr = Phasor_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Phasor_setProcMode;
 
     static char *kwlist[] = {"freq", "phase", "mul", "add", NULL};
 
@@ -3422,44 +3422,44 @@ Pointer_setProcMode(Pointer *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Pointer_readframes_a;
+    self->proc_func_ptr = (void (*)(void *))Pointer_readframes_a;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Pointer_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Pointer_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Pointer_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Pointer_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Pointer_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Pointer_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Pointer_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Pointer_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Pointer_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer_postprocessing_revareva;
             break;
     }
 }
@@ -3511,7 +3511,7 @@ Pointer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Pointer_compute_next_data_frame);
-    self->mode_func_ptr = Pointer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Pointer_setProcMode;
 
     static char *kwlist[] = {"table", "index", "mul", "add", NULL};
 
@@ -3798,44 +3798,44 @@ Pointer2_setProcMode(Pointer2 *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Pointer2_readframes_a;
+    self->proc_func_ptr = (void (*)(void *))Pointer2_readframes_a;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Pointer2_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Pointer2_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Pointer2_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Pointer2_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Pointer2_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Pointer2_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Pointer2_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Pointer2_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Pointer2_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Pointer2_postprocessing_revareva;
             break;
     }
 }
@@ -3890,7 +3890,7 @@ Pointer2_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Pointer2_compute_next_data_frame);
-    self->mode_func_ptr = Pointer2_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Pointer2_setProcMode;
 
     self->mTwoPiOverSr = -TWOPI / self->sr;
 
@@ -4180,44 +4180,44 @@ TableIndex_setProcMode(TableIndex *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TableIndex_readframes_a;
+    self->proc_func_ptr = (void (*)(void *))TableIndex_readframes_a;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TableIndex_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TableIndex_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TableIndex_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TableIndex_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TableIndex_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TableIndex_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TableIndex_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TableIndex_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TableIndex_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TableIndex_postprocessing_revareva;
             break;
     }
 }
@@ -4269,7 +4269,7 @@ TableIndex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TableIndex_compute_next_data_frame);
-    self->mode_func_ptr = TableIndex_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TableIndex_setProcMode;
 
     static char *kwlist[] = {"table", "index", "mul", "add", NULL};
 
@@ -4533,44 +4533,44 @@ Lookup_setProcMode(Lookup *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Lookup_readframes_a;
+    self->proc_func_ptr = (void (*)(void *))Lookup_readframes_a;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Lookup_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Lookup_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Lookup_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Lookup_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Lookup_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Lookup_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Lookup_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Lookup_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Lookup_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Lookup_postprocessing_revareva;
             break;
     }
 }
@@ -4622,7 +4622,7 @@ Lookup_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Lookup_compute_next_data_frame);
-    self->mode_func_ptr = Lookup_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Lookup_setProcMode;
 
     static char *kwlist[] = {"table", "index", "mul", "add", NULL};
 
@@ -5291,74 +5291,74 @@ Pulsar_setProcMode(Pulsar *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Pulsar_readframes_iii;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Pulsar_readframes_aii;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Pulsar_readframes_iai;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Pulsar_readframes_aai;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Pulsar_readframes_iia;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Pulsar_readframes_aia;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Pulsar_readframes_iaa;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Pulsar_readframes_aaa;
+            self->proc_func_ptr = (void (*)(void *))Pulsar_readframes_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Pulsar_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Pulsar_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Pulsar_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Pulsar_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Pulsar_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Pulsar_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Pulsar_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Pulsar_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Pulsar_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Pulsar_postprocessing_revareva;
             break;
     }
 }
@@ -5420,7 +5420,7 @@ Pulsar_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Pulsar_compute_next_data_frame);
-    self->mode_func_ptr = Pulsar_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Pulsar_setProcMode;
 
     static char *kwlist[] = {"table", "env", "freq", "frac", "phase", "interp", "mul", "add", NULL};
 
@@ -5833,50 +5833,50 @@ TableRead_setProcMode(TableRead *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TableRead_readframes_i;
+            self->proc_func_ptr = (void (*)(void *))TableRead_readframes_i;
             break;
 
         case 1:
-            self->proc_func_ptr = TableRead_readframes_a;
+            self->proc_func_ptr = (void (*)(void *))TableRead_readframes_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TableRead_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TableRead_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TableRead_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TableRead_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TableRead_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TableRead_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TableRead_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TableRead_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TableRead_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TableRead_postprocessing_revareva;
             break;
     }
 }
@@ -5937,7 +5937,7 @@ TableRead_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TableRead_compute_next_data_frame);
-    self->mode_func_ptr = TableRead_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TableRead_setProcMode;
 
     static char *kwlist[] = {"table", "freq", "loop", "interp", "mul", "add", NULL};
 
@@ -6529,74 +6529,74 @@ Fm_setProcMode(Fm *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Fm_readframes_iii;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Fm_readframes_aii;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Fm_readframes_iai;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Fm_readframes_aai;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Fm_readframes_iia;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Fm_readframes_aia;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Fm_readframes_iaa;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Fm_readframes_aaa;
+            self->proc_func_ptr = (void (*)(void *))Fm_readframes_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Fm_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Fm_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Fm_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Fm_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Fm_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Fm_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Fm_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Fm_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Fm_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Fm_postprocessing_revareva;
             break;
     }
 }
@@ -6657,7 +6657,7 @@ Fm_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Fm_compute_next_data_frame);
-    self->mode_func_ptr = Fm_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Fm_setProcMode;
 
     self->scaleFactor = 512.0 / self->sr;
 
@@ -6977,44 +6977,44 @@ CrossFm_setProcMode(CrossFm *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = CrossFm_readframes;
+    self->proc_func_ptr = (void (*)(void *))CrossFm_readframes;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = CrossFm_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = CrossFm_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = CrossFm_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = CrossFm_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = CrossFm_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = CrossFm_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = CrossFm_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = CrossFm_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = CrossFm_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))CrossFm_postprocessing_revareva;
             break;
     }
 }
@@ -7080,7 +7080,7 @@ CrossFm_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CrossFm_compute_next_data_frame);
-    self->mode_func_ptr = CrossFm_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CrossFm_setProcMode;
 
     self->scaleFactor = 512.0 / self->sr;
 
@@ -7431,58 +7431,58 @@ Blit_setProcMode(Blit *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Blit_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Blit_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Blit_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Blit_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Blit_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Blit_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Blit_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Blit_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Blit_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Blit_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Blit_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Blit_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Blit_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Blit_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Blit_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Blit_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Blit_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Blit_postprocessing_revareva;
             break;
     }
 }
@@ -7539,7 +7539,7 @@ Blit_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Blit_compute_next_data_frame);
-    self->mode_func_ptr = Blit_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Blit_setProcMode;
 
     static char *kwlist[] = {"freq", "harms", "mul", "add", NULL};
 
@@ -7911,58 +7911,58 @@ Rossler_setProcMode(Rossler *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Rossler_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Rossler_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Rossler_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Rossler_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Rossler_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Rossler_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Rossler_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Rossler_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Rossler_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Rossler_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Rossler_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Rossler_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Rossler_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Rossler_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Rossler_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Rossler_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Rossler_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Rossler_postprocessing_revareva;
             break;
     }
 }
@@ -8023,7 +8023,7 @@ Rossler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Rossler_compute_next_data_frame);
-    self->mode_func_ptr = Rossler_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Rossler_setProcMode;
 
     self->scalePitch = 2.91 / self->sr;
 
@@ -8228,39 +8228,39 @@ RosslerAlt_setProcMode(RosslerAlt *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = RosslerAlt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))RosslerAlt_postprocessing_revareva;
             break;
     }
 }
@@ -8318,7 +8318,7 @@ RosslerAlt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RosslerAlt_compute_next_data_frame);
-    self->mode_func_ptr = RosslerAlt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RosslerAlt_setProcMode;
 
     static char *kwlist[] = {"mainRossler", "mul", "alt", NULL};
 
@@ -8675,58 +8675,58 @@ Lorenz_setProcMode(Lorenz *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Lorenz_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))Lorenz_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Lorenz_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))Lorenz_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Lorenz_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))Lorenz_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Lorenz_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))Lorenz_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Lorenz_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Lorenz_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Lorenz_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Lorenz_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Lorenz_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Lorenz_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Lorenz_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Lorenz_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Lorenz_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Lorenz_postprocessing_revareva;
             break;
     }
 }
@@ -8787,7 +8787,7 @@ Lorenz_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Lorenz_compute_next_data_frame);
-    self->mode_func_ptr = Lorenz_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Lorenz_setProcMode;
 
     self->oneOnSr = 1.0 / self->sr;
 
@@ -8992,39 +8992,39 @@ LorenzAlt_setProcMode(LorenzAlt *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = LorenzAlt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))LorenzAlt_postprocessing_revareva;
             break;
     }
 }
@@ -9082,7 +9082,7 @@ LorenzAlt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, LorenzAlt_compute_next_data_frame);
-    self->mode_func_ptr = LorenzAlt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))LorenzAlt_setProcMode;
 
     static char *kwlist[] = {"mainLorenz", "mul", "alt", NULL};
 
@@ -9447,58 +9447,58 @@ ChenLee_setProcMode(ChenLee *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = ChenLee_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))ChenLee_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = ChenLee_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))ChenLee_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = ChenLee_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))ChenLee_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = ChenLee_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))ChenLee_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ChenLee_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ChenLee_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ChenLee_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ChenLee_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ChenLee_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ChenLee_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ChenLee_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ChenLee_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ChenLee_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLee_postprocessing_revareva;
             break;
     }
 }
@@ -9559,7 +9559,7 @@ ChenLee_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, ChenLee_compute_next_data_frame);
-    self->mode_func_ptr = ChenLee_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ChenLee_setProcMode;
 
     self->oneOnSr = 1.0 / self->sr;
 
@@ -9764,39 +9764,39 @@ ChenLeeAlt_setProcMode(ChenLeeAlt *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ChenLeeAlt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ChenLeeAlt_postprocessing_revareva;
             break;
     }
 }
@@ -9854,7 +9854,7 @@ ChenLeeAlt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, ChenLeeAlt_compute_next_data_frame);
-    self->mode_func_ptr = ChenLeeAlt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ChenLeeAlt_setProcMode;
 
     static char *kwlist[] = {"mainChenLee", "mul", "alt", NULL};
 
@@ -10404,74 +10404,74 @@ SumOsc_setProcMode(SumOsc *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SumOsc_readframes_iii;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = SumOsc_readframes_aii;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = SumOsc_readframes_iai;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = SumOsc_readframes_aai;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = SumOsc_readframes_iia;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = SumOsc_readframes_aia;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = SumOsc_readframes_iaa;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = SumOsc_readframes_aaa;
+            self->proc_func_ptr = (void (*)(void *))SumOsc_readframes_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SumOsc_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SumOsc_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SumOsc_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SumOsc_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SumOsc_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SumOsc_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SumOsc_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SumOsc_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SumOsc_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SumOsc_postprocessing_revareva;
             break;
     }
 }
@@ -10533,7 +10533,7 @@ SumOsc_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SumOsc_compute_next_data_frame);
-    self->mode_func_ptr = SumOsc_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SumOsc_setProcMode;
 
     self->scaleFactor = 512.0 / self->sr;
 
@@ -11247,74 +11247,74 @@ SuperSaw_setProcMode(SuperSaw *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SuperSaw_readframes_iii;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = SuperSaw_readframes_aii;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = SuperSaw_readframes_iai;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = SuperSaw_readframes_aai;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = SuperSaw_readframes_iia;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = SuperSaw_readframes_aia;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = SuperSaw_readframes_iaa;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = SuperSaw_readframes_aaa;
+            self->proc_func_ptr = (void (*)(void *))SuperSaw_readframes_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SuperSaw_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SuperSaw_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SuperSaw_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SuperSaw_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SuperSaw_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SuperSaw_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SuperSaw_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SuperSaw_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SuperSaw_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SuperSaw_postprocessing_revareva;
             break;
     }
 }
@@ -11386,7 +11386,7 @@ SuperSaw_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->nyquist = (MYFLT)self->sr * 0.49;
 
     Stream_setFunctionPtr(self->stream, SuperSaw_compute_next_data_frame);
-    self->mode_func_ptr = SuperSaw_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SuperSaw_setProcMode;
 
     static char *kwlist[] = {"freq", "detune", "bal", "mul", "add", NULL};
 
@@ -11734,58 +11734,58 @@ RCOsc_setProcMode(RCOsc *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = RCOsc_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))RCOsc_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = RCOsc_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))RCOsc_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = RCOsc_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))RCOsc_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = RCOsc_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))RCOsc_readframes_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = RCOsc_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = RCOsc_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = RCOsc_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = RCOsc_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = RCOsc_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = RCOsc_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = RCOsc_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = RCOsc_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = RCOsc_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))RCOsc_postprocessing_revareva;
             break;
     }
 }
@@ -11842,7 +11842,7 @@ RCOsc_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RCOsc_compute_next_data_frame);
-    self->mode_func_ptr = RCOsc_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RCOsc_setProcMode;
 
     static char *kwlist[] = {"freq", "sharp", "mul", "add", NULL};
 
@@ -12117,19 +12117,19 @@ TableScale_setProcMode(TableScale *self)
     switch (muladdmode)
     {
         case 0:
-            self->proc_func_ptr = TableScale_readframes_ii;
+            self->proc_func_ptr = (void (*)(void *))TableScale_readframes_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = TableScale_readframes_ai;
+            self->proc_func_ptr = (void (*)(void *))TableScale_readframes_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = TableScale_readframes_ia;
+            self->proc_func_ptr = (void (*)(void *))TableScale_readframes_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = TableScale_readframes_aa;
+            self->proc_func_ptr = (void (*)(void *))TableScale_readframes_aa;
             break;
     }
 }
@@ -12176,7 +12176,7 @@ TableScale_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TableScale_compute_next_data_frame);
-    self->mode_func_ptr = TableScale_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TableScale_setProcMode;
 
     static char *kwlist[] = {"table", "outtable", "mul", "add", NULL};
 
@@ -12602,44 +12602,44 @@ TableScan_setProcMode(TableScan *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TableScan_readframes;
+    self->proc_func_ptr = (void (*)(void *))TableScan_readframes;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TableScan_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TableScan_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TableScan_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TableScan_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TableScan_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TableScan_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TableScan_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TableScan_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TableScan_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TableScan_postprocessing_revareva;
             break;
     }
 }
@@ -12688,7 +12688,7 @@ TableScan_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TableScan_compute_next_data_frame);
-    self->mode_func_ptr = TableScan_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TableScan_setProcMode;
 
     static char *kwlist[] = {"table", "mul", "add", NULL};
 

--- a/src/objects/oscmodule.c
+++ b/src/objects/oscmodule.c
@@ -303,39 +303,39 @@ OscReceive_setProcMode(OscReceive *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = OscReceive_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = OscReceive_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = OscReceive_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = OscReceive_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = OscReceive_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = OscReceive_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = OscReceive_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = OscReceive_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = OscReceive_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))OscReceive_postprocessing_revareva;
             break;
     }
 }
@@ -409,7 +409,7 @@ OscReceive_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->factor = 1. / (0.01 * self->sr);
 
     Stream_setFunctionPtr(self->stream, OscReceive_compute_next_data_frame);
-    self->mode_func_ptr = OscReceive_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))OscReceive_setProcMode;
 
     static char *kwlist[] = {"input", "address", "mul", "add", NULL};
 
@@ -1673,39 +1673,39 @@ OscListReceive_setProcMode(OscListReceive *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = OscListReceive_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = OscListReceive_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = OscListReceive_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = OscListReceive_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = OscListReceive_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = OscListReceive_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = OscListReceive_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = OscListReceive_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = OscListReceive_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))OscListReceive_postprocessing_revareva;
             break;
     }
 }
@@ -1782,7 +1782,7 @@ OscListReceive_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->factor = 1. / (0.01 * self->sr);
 
     Stream_setFunctionPtr(self->stream, OscListReceive_compute_next_data_frame);
-    self->mode_func_ptr = OscListReceive_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))OscListReceive_setProcMode;
 
     static char *kwlist[] = {"input", "address", "order", "mul", "add", NULL};
 

--- a/src/objects/panmodule.c
+++ b/src/objects/panmodule.c
@@ -224,19 +224,19 @@ Panner_setProcMode(Panner *self)
         switch (procmode)
         {
             case 0:
-                self->proc_func_ptr = Panner_splitter_ii;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_ii;
                 break;
 
             case 1:
-                self->proc_func_ptr = Panner_splitter_ai;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_ai;
                 break;
 
             case 10:
-                self->proc_func_ptr = Panner_splitter_ia;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_ia;
                 break;
 
             case 11:
-                self->proc_func_ptr = Panner_splitter_aa;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_aa;
                 break;
         }
     }
@@ -245,17 +245,17 @@ Panner_setProcMode(Panner *self)
         switch (self->modebuffer[0])
         {
             case 0:
-                self->proc_func_ptr = Panner_splitter_st_i;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_st_i;
                 break;
 
             case 1:
-                self->proc_func_ptr = Panner_splitter_st_a;
+                self->proc_func_ptr = (void (*)(void *))Panner_splitter_st_a;
                 break;
         }
     }
     else if (self->chnls == 1)
     {
-        self->proc_func_ptr = Panner_splitter_thru;
+        self->proc_func_ptr = (void (*)(void *))Panner_splitter_thru;
     }
 }
 
@@ -305,7 +305,7 @@ Panner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Panner_compute_next_data_frame);
-    self->mode_func_ptr = Panner_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Panner_setProcMode;
 
     self->pan = PyFloat_FromDouble(0.5);
     self->spread = PyFloat_FromDouble(0.5);
@@ -444,39 +444,39 @@ Pan_setProcMode(Pan *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Pan_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Pan_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Pan_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Pan_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Pan_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Pan_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Pan_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Pan_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Pan_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Pan_postprocessing_revareva;
             break;
     }
 }
@@ -535,7 +535,7 @@ Pan_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Pan_compute_next_data_frame);
-    self->mode_func_ptr = Pan_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Pan_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -863,11 +863,11 @@ SPanner_setProcMode(SPanner *self)
         switch (procmode)
         {
             case 0:
-                self->proc_func_ptr = SPanner_splitter_i;
+                self->proc_func_ptr = (void (*)(void *))SPanner_splitter_i;
                 break;
 
             case 1:
-                self->proc_func_ptr = SPanner_splitter_a;
+                self->proc_func_ptr = (void (*)(void *))SPanner_splitter_a;
                 break;
         }
     }
@@ -876,17 +876,17 @@ SPanner_setProcMode(SPanner *self)
         switch (self->modebuffer[0])
         {
             case 0:
-                self->proc_func_ptr = SPanner_splitter_st_i;
+                self->proc_func_ptr = (void (*)(void *))SPanner_splitter_st_i;
                 break;
 
             case 1:
-                self->proc_func_ptr = SPanner_splitter_st_a;
+                self->proc_func_ptr = (void (*)(void *))SPanner_splitter_st_a;
                 break;
         }
     }
     else if (self->chnls == 1)
     {
-        self->proc_func_ptr = SPanner_splitter_thru;
+        self->proc_func_ptr = (void (*)(void *))SPanner_splitter_thru;
     }
 }
 
@@ -934,7 +934,7 @@ SPanner_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SPanner_compute_next_data_frame);
-    self->mode_func_ptr = SPanner_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SPanner_setProcMode;
 
     self->pan = PyFloat_FromDouble(0.5);
     self->chnls = 2;
@@ -1072,39 +1072,39 @@ SPan_setProcMode(SPan *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SPan_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SPan_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SPan_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SPan_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SPan_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SPan_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SPan_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SPan_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SPan_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SPan_postprocessing_revareva;
             break;
     }
 }
@@ -1163,7 +1163,7 @@ SPan_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SPan_compute_next_data_frame);
-    self->mode_func_ptr = SPan_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SPan_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -1432,11 +1432,11 @@ Switcher_setProcMode(Switcher *self)
     switch (self->modebuffer[0])
     {
         case 0:
-            self->proc_func_ptr = Switcher_splitter_i;
+            self->proc_func_ptr = (void (*)(void *))Switcher_splitter_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Switcher_splitter_a;
+            self->proc_func_ptr = (void (*)(void *))Switcher_splitter_a;
             break;
     }
 }
@@ -1485,7 +1485,7 @@ Switcher_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Switcher_compute_next_data_frame);
-    self->mode_func_ptr = Switcher_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Switcher_setProcMode;
 
     self->voice = PyFloat_FromDouble(0.0);
     self->chnls = 2;
@@ -1620,39 +1620,39 @@ Switch_setProcMode(Switch *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Switch_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Switch_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Switch_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Switch_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Switch_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Switch_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Switch_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Switch_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Switch_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Switch_postprocessing_revareva;
             break;
     }
 }
@@ -1711,7 +1711,7 @@ Switch_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Switch_compute_next_data_frame);
-    self->mode_func_ptr = Switch_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Switch_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 
@@ -1929,44 +1929,44 @@ VoiceManager_setProcMode(VoiceManager *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = VoiceManager_generate;
+    self->proc_func_ptr = (void (*)(void *))VoiceManager_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = VoiceManager_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = VoiceManager_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = VoiceManager_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = VoiceManager_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = VoiceManager_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = VoiceManager_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = VoiceManager_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = VoiceManager_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = VoiceManager_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))VoiceManager_postprocessing_revareva;
             break;
     }
 }
@@ -2024,7 +2024,7 @@ VoiceManager_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, VoiceManager_compute_next_data_frame);
-    self->mode_func_ptr = VoiceManager_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))VoiceManager_setProcMode;
 
     static char *kwlist[] = {"input", "triggers", "mul", "add", NULL};
 
@@ -2299,7 +2299,7 @@ Mixer_getSamplesBuffer(Mixer *self)
 static void
 Mixer_setProcMode(Mixer *self)
 {
-    self->proc_func_ptr = Mixer_generate;
+    self->proc_func_ptr = (void (*)(void *))Mixer_generate;
 }
 
 static void
@@ -2364,7 +2364,7 @@ Mixer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Mixer_compute_next_data_frame);
-    self->mode_func_ptr = Mixer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Mixer_setProcMode;
 
     static char *kwlist[] = {"outs", "time", NULL};
 
@@ -2617,39 +2617,39 @@ MixerVoice_setProcMode(MixerVoice *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MixerVoice_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MixerVoice_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MixerVoice_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MixerVoice_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MixerVoice_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MixerVoice_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MixerVoice_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MixerVoice_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MixerVoice_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MixerVoice_postprocessing_revareva;
             break;
     }
 }
@@ -2708,7 +2708,7 @@ MixerVoice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MixerVoice_compute_next_data_frame);
-    self->mode_func_ptr = MixerVoice_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MixerVoice_setProcMode;
 
     static char *kwlist[] = {"mainMixer", "chnl", "mul", "add", NULL};
 
@@ -3047,17 +3047,17 @@ Selector_setProcMode(Selector *self)
     {
         case 0:
             if (self->mode == 0)
-                self->proc_func_ptr = Selector_generate_i;
+                self->proc_func_ptr = (void (*)(void *))Selector_generate_i;
             else
-                self->proc_func_ptr = Selector_generate_lin_i;
+                self->proc_func_ptr = (void (*)(void *))Selector_generate_lin_i;
 
             break;
 
         case 1:
             if (self->mode == 0)
-                self->proc_func_ptr = Selector_generate_a;
+                self->proc_func_ptr = (void (*)(void *))Selector_generate_a;
             else
-                self->proc_func_ptr = Selector_generate_lin_a;
+                self->proc_func_ptr = (void (*)(void *))Selector_generate_lin_a;
 
             break;
     }
@@ -3065,39 +3065,39 @@ Selector_setProcMode(Selector *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Selector_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Selector_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Selector_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Selector_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Selector_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Selector_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Selector_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Selector_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Selector_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Selector_postprocessing_revareva;
             break;
     }
 }
@@ -3152,7 +3152,7 @@ Selector_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Selector_compute_next_data_frame);
-    self->mode_func_ptr = Selector_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Selector_setProcMode;
 
     static char *kwlist[] = {"inputs", "voice", "mul", "add", NULL};
 

--- a/src/objects/patternmodule.c
+++ b/src/objects/patternmodule.c
@@ -147,11 +147,11 @@ Pattern_setProcMode(Pattern *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Pattern_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Pattern_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Pattern_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Pattern_generate_a;
             break;
     }
 }
@@ -206,7 +206,7 @@ Pattern_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Pattern_compute_next_data_frame);
-    self->mode_func_ptr = Pattern_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Pattern_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
     self->currentTime = 0.;
@@ -385,7 +385,7 @@ Score_selector(Score *self)
 static void
 Score_setProcMode(Score *self)
 {
-    self->proc_func_ptr = Score_selector;
+    self->proc_func_ptr = (void (*)(void *))Score_selector;
 }
 
 static void
@@ -431,7 +431,7 @@ Score_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Score_compute_next_data_frame);
-    self->mode_func_ptr = Score_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Score_setProcMode;
 
     static char *kwlist[] = {"input", "fname", NULL};
 
@@ -564,7 +564,7 @@ CallAfter_generate(CallAfter *self)
 static void
 CallAfter_setProcMode(CallAfter *self)
 {
-    self->proc_func_ptr = CallAfter_generate;
+    self->proc_func_ptr = (void (*)(void *))CallAfter_generate;
 }
 
 static void
@@ -613,7 +613,7 @@ CallAfter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CallAfter_compute_next_data_frame);
-    self->mode_func_ptr = CallAfter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CallAfter_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
     self->currentTime = 0.;

--- a/src/objects/phasevocmodule.c
+++ b/src/objects/phasevocmodule.c
@@ -240,7 +240,7 @@ PVAnal_process(PVAnal *self)
 static void
 PVAnal_setProcMode(PVAnal *self)
 {
-    self->proc_func_ptr = PVAnal_process;
+    self->proc_func_ptr = (void (*)(void *))PVAnal_process;
 }
 
 static void
@@ -328,7 +328,7 @@ PVAnal_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVAnal_compute_next_data_frame);
-    self->mode_func_ptr = PVAnal_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVAnal_setProcMode;
 
     static char *kwlist[] = {"input", "size", "olaps", "wintype", "callback", NULL};
 
@@ -685,44 +685,44 @@ PVSynth_setProcMode(PVSynth *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = PVSynth_process;
+    self->proc_func_ptr = (void (*)(void *))PVSynth_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = PVSynth_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = PVSynth_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = PVSynth_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = PVSynth_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = PVSynth_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = PVSynth_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = PVSynth_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = PVSynth_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = PVSynth_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))PVSynth_postprocessing_revareva;
             break;
     }
 }
@@ -790,7 +790,7 @@ PVSynth_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVSynth_compute_next_data_frame);
-    self->mode_func_ptr = PVSynth_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVSynth_setProcMode;
 
     static char *kwlist[] = {"input", "wintype", "mul", "add", NULL};
 
@@ -1198,50 +1198,50 @@ PVAddSynth_setProcMode(PVAddSynth *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVAddSynth_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVAddSynth_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVAddSynth_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVAddSynth_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = PVAddSynth_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))PVAddSynth_postprocessing_revareva;
             break;
     }
 }
@@ -1304,7 +1304,7 @@ PVAddSynth_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVAddSynth_compute_next_data_frame);
-    self->mode_func_ptr = PVAddSynth_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVAddSynth_setProcMode;
 
     static char *kwlist[] = {"input", "pitch", "num", "first", "inc", "mul", "add", NULL};
 
@@ -1737,11 +1737,11 @@ PVTranspose_setProcMode(PVTranspose *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVTranspose_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVTranspose_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVTranspose_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVTranspose_process_a;
             break;
     }
 }
@@ -1805,7 +1805,7 @@ PVTranspose_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVTranspose_compute_next_data_frame);
-    self->mode_func_ptr = PVTranspose_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVTranspose_setProcMode;
 
     static char *kwlist[] = {"input", "transpo", NULL};
 
@@ -2299,19 +2299,19 @@ PVVerb_setProcMode(PVVerb *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVVerb_process_ii;
+            self->proc_func_ptr = (void (*)(void *))PVVerb_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = PVVerb_process_ai;
+            self->proc_func_ptr = (void (*)(void *))PVVerb_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = PVVerb_process_ia;
+            self->proc_func_ptr = (void (*)(void *))PVVerb_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = PVVerb_process_aa;
+            self->proc_func_ptr = (void (*)(void *))PVVerb_process_aa;
             break;
     }
 }
@@ -2380,7 +2380,7 @@ PVVerb_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVVerb_compute_next_data_frame);
-    self->mode_func_ptr = PVVerb_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVVerb_setProcMode;
 
     static char *kwlist[] = {"input", "revtime", "damp", NULL};
 
@@ -2859,19 +2859,19 @@ PVGate_setProcMode(PVGate *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVGate_process_ii;
+            self->proc_func_ptr = (void (*)(void *))PVGate_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = PVGate_process_ai;
+            self->proc_func_ptr = (void (*)(void *))PVGate_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = PVGate_process_ia;
+            self->proc_func_ptr = (void (*)(void *))PVGate_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = PVGate_process_aa;
+            self->proc_func_ptr = (void (*)(void *))PVGate_process_aa;
             break;
     }
 }
@@ -2939,7 +2939,7 @@ PVGate_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->inverse = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVGate_compute_next_data_frame);
-    self->mode_func_ptr = PVGate_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVGate_setProcMode;
 
     static char *kwlist[] = {"input", "thresh", "damp", "inverse", NULL};
 
@@ -3250,11 +3250,11 @@ PVCross_setProcMode(PVCross *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVCross_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVCross_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVCross_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVCross_process_a;
             break;
     }
 }
@@ -3320,7 +3320,7 @@ PVCross_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVCross_compute_next_data_frame);
-    self->mode_func_ptr = PVCross_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVCross_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "fade", NULL};
 
@@ -3586,7 +3586,7 @@ PVMult_process_i(PVMult *self)
 static void
 PVMult_setProcMode(PVMult *self)
 {
-    self->proc_func_ptr = PVMult_process_i;
+    self->proc_func_ptr = (void (*)(void *))PVMult_process_i;
 }
 
 static void
@@ -3647,7 +3647,7 @@ PVMult_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVMult_compute_next_data_frame);
-    self->mode_func_ptr = PVMult_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVMult_setProcMode;
 
     static char *kwlist[] = {"input", "input2", NULL};
 
@@ -3967,11 +3967,11 @@ PVMorph_setProcMode(PVMorph *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVMorph_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVMorph_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVMorph_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVMorph_process_a;
             break;
     }
 }
@@ -4037,7 +4037,7 @@ PVMorph_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVMorph_compute_next_data_frame);
-    self->mode_func_ptr = PVMorph_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVMorph_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "fade", NULL};
 
@@ -4414,11 +4414,11 @@ PVFilter_setProcMode(PVFilter *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVFilter_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVFilter_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVFilter_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVFilter_process_a;
             break;
     }
 }
@@ -4484,7 +4484,7 @@ PVFilter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                        1 : index between 0 and hsize are scaled over table length */
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVFilter_compute_next_data_frame);
-    self->mode_func_ptr = PVFilter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVFilter_setProcMode;
 
     static char *kwlist[] = {"input", "table", "gain", "mode", NULL};
 
@@ -4921,9 +4921,9 @@ static void
 PVDelay_setProcMode(PVDelay *self)
 {
     if (self->mode == 0)
-        self->proc_func_ptr = PVDelay_process_zero;
+        self->proc_func_ptr = (void (*)(void *))PVDelay_process_zero;
     else
-        self->proc_func_ptr = PVDelay_process_scaled;
+        self->proc_func_ptr = (void (*)(void *))PVDelay_process_scaled;
 }
 
 static void
@@ -4994,7 +4994,7 @@ PVDelay_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->mode = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVDelay_compute_next_data_frame);
-    self->mode_func_ptr = PVDelay_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVDelay_setProcMode;
 
     static char *kwlist[] = {"input", "deltable", "feedtable", "maxdelay", "mode", NULL};
 
@@ -5431,11 +5431,11 @@ PVBuffer_setProcMode(PVBuffer *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVBuffer_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVBuffer_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVBuffer_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVBuffer_process_a;
             break;
     }
 }
@@ -5514,7 +5514,7 @@ PVBuffer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->length = 1.0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVBuffer_compute_next_data_frame);
-    self->mode_func_ptr = PVBuffer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVBuffer_setProcMode;
 
     static char *kwlist[] = {"input", "index", "pitch", "length", NULL};
 
@@ -5878,11 +5878,11 @@ PVShift_setProcMode(PVShift *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVShift_process_i;
+            self->proc_func_ptr = (void (*)(void *))PVShift_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = PVShift_process_a;
+            self->proc_func_ptr = (void (*)(void *))PVShift_process_a;
             break;
     }
 }
@@ -5946,7 +5946,7 @@ PVShift_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVShift_compute_next_data_frame);
-    self->mode_func_ptr = PVShift_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVShift_setProcMode;
 
     static char *kwlist[] = {"input", "shift", NULL};
 
@@ -6464,19 +6464,19 @@ PVAmpMod_setProcMode(PVAmpMod *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVAmpMod_process_ii;
+            self->proc_func_ptr = (void (*)(void *))PVAmpMod_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = PVAmpMod_process_ai;
+            self->proc_func_ptr = (void (*)(void *))PVAmpMod_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = PVAmpMod_process_ia;
+            self->proc_func_ptr = (void (*)(void *))PVAmpMod_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = PVAmpMod_process_aa;
+            self->proc_func_ptr = (void (*)(void *))PVAmpMod_process_aa;
             break;
     }
 }
@@ -6545,7 +6545,7 @@ PVAmpMod_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVAmpMod_compute_next_data_frame);
-    self->mode_func_ptr = PVAmpMod_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVAmpMod_setProcMode;
 
     static char *kwlist[] = {"input", "basefreq", "spread", "shape", NULL};
 
@@ -7108,19 +7108,19 @@ PVFreqMod_setProcMode(PVFreqMod *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = PVFreqMod_process_ii;
+            self->proc_func_ptr = (void (*)(void *))PVFreqMod_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = PVFreqMod_process_ai;
+            self->proc_func_ptr = (void (*)(void *))PVFreqMod_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = PVFreqMod_process_ia;
+            self->proc_func_ptr = (void (*)(void *))PVFreqMod_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = PVFreqMod_process_aa;
+            self->proc_func_ptr = (void (*)(void *))PVFreqMod_process_aa;
             break;
     }
 }
@@ -7192,7 +7192,7 @@ PVFreqMod_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVFreqMod_compute_next_data_frame);
-    self->mode_func_ptr = PVFreqMod_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVFreqMod_setProcMode;
 
     static char *kwlist[] = {"input", "basefreq", "spread", "depth", "shape", NULL};
 
@@ -7652,7 +7652,7 @@ PVBufLoops_process(PVBufLoops *self)
 static void
 PVBufLoops_setProcMode(PVBufLoops *self)
 {
-    self->proc_func_ptr = PVBufLoops_process;
+    self->proc_func_ptr = (void (*)(void *))PVBufLoops_process;
 }
 
 static void
@@ -7733,7 +7733,7 @@ PVBufLoops_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->length = 1.0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVBufLoops_compute_next_data_frame);
-    self->mode_func_ptr = PVBufLoops_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVBufLoops_setProcMode;
 
     static char *kwlist[] = {"input", "low", "high", "mode", "length", NULL};
 
@@ -8085,7 +8085,7 @@ PVBufTabLoops_process(PVBufTabLoops *self)
 static void
 PVBufTabLoops_setProcMode(PVBufTabLoops *self)
 {
-    self->proc_func_ptr = PVBufTabLoops_process;
+    self->proc_func_ptr = (void (*)(void *))PVBufTabLoops_process;
 }
 
 static void
@@ -8156,7 +8156,7 @@ PVBufTabLoops_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->length = 1.0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVBufTabLoops_compute_next_data_frame);
-    self->mode_func_ptr = PVBufTabLoops_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVBufTabLoops_setProcMode;
 
     static char *kwlist[] = {"input", "speed", "length", NULL};
 
@@ -8430,7 +8430,7 @@ PVMix_process_i(PVMix *self)
 static void
 PVMix_setProcMode(PVMix *self)
 {
-    self->proc_func_ptr = PVMix_process_i;
+    self->proc_func_ptr = (void (*)(void *))PVMix_process_i;
 }
 
 static void
@@ -8491,7 +8491,7 @@ PVMix_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->allocated = 0;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, PVMix_compute_next_data_frame);
-    self->mode_func_ptr = PVMix_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))PVMix_setProcMode;
 
     static char *kwlist[] = {"input", "input2", NULL};
 

--- a/src/objects/randommodule.c
+++ b/src/objects/randommodule.c
@@ -294,74 +294,74 @@ Randi_setProcMode(Randi *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Randi_generate_iii;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Randi_generate_aii;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Randi_generate_iai;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Randi_generate_aai;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Randi_generate_iia;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Randi_generate_aia;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Randi_generate_iaa;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Randi_generate_aaa;
+            self->proc_func_ptr = (void (*)(void *))Randi_generate_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Randi_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Randi_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Randi_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Randi_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Randi_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Randi_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Randi_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Randi_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Randi_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Randi_postprocessing_revareva;
             break;
     }
 }
@@ -424,7 +424,7 @@ Randi_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Randi_compute_next_data_frame);
-    self->mode_func_ptr = Randi_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Randi_setProcMode;
 
     static char *kwlist[] = {"min", "max", "freq", "mul", "add", NULL};
 
@@ -863,74 +863,74 @@ Randh_setProcMode(Randh *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Randh_generate_iii;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Randh_generate_aii;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Randh_generate_iai;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Randh_generate_aai;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Randh_generate_iia;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Randh_generate_aia;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Randh_generate_iaa;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Randh_generate_aaa;
+            self->proc_func_ptr = (void (*)(void *))Randh_generate_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Randh_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Randh_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Randh_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Randh_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Randh_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Randh_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Randh_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Randh_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Randh_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Randh_postprocessing_revareva;
             break;
     }
 }
@@ -993,7 +993,7 @@ Randh_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Randh_compute_next_data_frame);
-    self->mode_func_ptr = Randh_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Randh_setProcMode;
 
     static char *kwlist[] = {"min", "max", "freq", "mul", "add", NULL};
 
@@ -1262,50 +1262,50 @@ Choice_setProcMode(Choice *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Choice_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Choice_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Choice_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Choice_generate_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Choice_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Choice_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Choice_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Choice_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Choice_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Choice_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Choice_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Choice_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Choice_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Choice_postprocessing_revareva;
             break;
     }
 }
@@ -1360,7 +1360,7 @@ Choice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Choice_compute_next_data_frame);
-    self->mode_func_ptr = Choice_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Choice_setProcMode;
 
     static char *kwlist[] = {"choice", "freq", "mul", "add", NULL};
 
@@ -1683,58 +1683,58 @@ RandInt_setProcMode(RandInt *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = RandInt_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))RandInt_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = RandInt_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))RandInt_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = RandInt_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))RandInt_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = RandInt_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))RandInt_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = RandInt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = RandInt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = RandInt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = RandInt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = RandInt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = RandInt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = RandInt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = RandInt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = RandInt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))RandInt_postprocessing_revareva;
             break;
     }
 }
@@ -1792,7 +1792,7 @@ RandInt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RandInt_compute_next_data_frame);
-    self->mode_func_ptr = RandInt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RandInt_setProcMode;
 
     static char *kwlist[] = {"max", "freq", "mul", "add", NULL};
 
@@ -2132,58 +2132,58 @@ RandDur_setProcMode(RandDur *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = RandDur_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))RandDur_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = RandDur_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))RandDur_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = RandDur_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))RandDur_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = RandDur_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))RandDur_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = RandDur_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = RandDur_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = RandDur_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = RandDur_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = RandDur_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = RandDur_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = RandDur_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = RandDur_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = RandDur_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))RandDur_postprocessing_revareva;
             break;
     }
 }
@@ -2242,7 +2242,7 @@ RandDur_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, RandDur_compute_next_data_frame);
-    self->mode_func_ptr = RandDur_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))RandDur_setProcMode;
 
     static char *kwlist[] = {"min", "max", "mul", "add", NULL};
 
@@ -2437,7 +2437,7 @@ typedef struct
     Stream *x1_stream;
     Stream *x2_stream;
     Stream *freq_stream;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     MYFLT xx1;
     MYFLT xx2;
     int type;
@@ -2950,55 +2950,55 @@ Xnoise_setRandomType(Xnoise *self)
     switch (self->type)
     {
         case 0:
-            self->type_func_ptr = Xnoise_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = Xnoise_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = Xnoise_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = Xnoise_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = Xnoise_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_expon_min;
             break;
 
         case 5:
-            self->type_func_ptr = Xnoise_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_expon_max;
             break;
 
         case 6:
-            self->type_func_ptr = Xnoise_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_biexpon;
             break;
 
         case 7:
-            self->type_func_ptr = Xnoise_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_cauchy;
             break;
 
         case 8:
-            self->type_func_ptr = Xnoise_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_weibull;
             break;
 
         case 9:
-            self->type_func_ptr = Xnoise_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_gaussian;
             break;
 
         case 10:
-            self->type_func_ptr = Xnoise_poisson;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_poisson;
             break;
 
         case 11:
-            self->type_func_ptr = Xnoise_walker;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_walker;
             break;
 
         case 12:
-            self->type_func_ptr = Xnoise_loopseg;
+            self->type_func_ptr = (MYFLT (*)(void *))Xnoise_loopseg;
             break;
     }
 }
@@ -3013,74 +3013,74 @@ Xnoise_setProcMode(Xnoise *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Xnoise_generate_iii;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = Xnoise_generate_aii;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = Xnoise_generate_iai;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = Xnoise_generate_aai;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = Xnoise_generate_iia;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = Xnoise_generate_aia;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = Xnoise_generate_iaa;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = Xnoise_generate_aaa;
+            self->proc_func_ptr = (void (*)(void *))Xnoise_generate_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Xnoise_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Xnoise_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Xnoise_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Xnoise_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Xnoise_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Xnoise_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Xnoise_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Xnoise_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Xnoise_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Xnoise_postprocessing_revareva;
             break;
     }
 }
@@ -3162,7 +3162,7 @@ Xnoise_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->loopLen = (pyorand() % 10) + 3;
 
     Stream_setFunctionPtr(self->stream, Xnoise_compute_next_data_frame);
-    self->mode_func_ptr = Xnoise_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Xnoise_setProcMode;
 
     static char *kwlist[] = {"type", "freq", "x1", "x2", "mul", "add", NULL};
 
@@ -3363,7 +3363,7 @@ typedef struct
     Stream *x1_stream;
     Stream *x2_stream;
     Stream *freq_stream;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     int scale; // 0 = Midi, 1 = frequency, 2 = transpo
     MYFLT xx1;
     MYFLT xx2;
@@ -3913,55 +3913,55 @@ XnoiseMidi_setRandomType(XnoiseMidi *self)
     switch (self->type)
     {
         case 0:
-            self->type_func_ptr = XnoiseMidi_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = XnoiseMidi_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = XnoiseMidi_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = XnoiseMidi_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = XnoiseMidi_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_expon_min;
             break;
 
         case 5:
-            self->type_func_ptr = XnoiseMidi_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_expon_max;
             break;
 
         case 6:
-            self->type_func_ptr = XnoiseMidi_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_biexpon;
             break;
 
         case 7:
-            self->type_func_ptr = XnoiseMidi_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_cauchy;
             break;
 
         case 8:
-            self->type_func_ptr = XnoiseMidi_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_weibull;
             break;
 
         case 9:
-            self->type_func_ptr = XnoiseMidi_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_gaussian;
             break;
 
         case 10:
-            self->type_func_ptr = XnoiseMidi_poisson;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_poisson;
             break;
 
         case 11:
-            self->type_func_ptr = XnoiseMidi_walker;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_walker;
             break;
 
         case 12:
-            self->type_func_ptr = XnoiseMidi_loopseg;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseMidi_loopseg;
             break;
     }
 }
@@ -3976,74 +3976,74 @@ XnoiseMidi_setProcMode(XnoiseMidi *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = XnoiseMidi_generate_iii;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_iii;
             break;
 
         case 1:
-            self->proc_func_ptr = XnoiseMidi_generate_aii;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_aii;
             break;
 
         case 10:
-            self->proc_func_ptr = XnoiseMidi_generate_iai;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_iai;
             break;
 
         case 11:
-            self->proc_func_ptr = XnoiseMidi_generate_aai;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_aai;
             break;
 
         case 100:
-            self->proc_func_ptr = XnoiseMidi_generate_iia;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_iia;
             break;
 
         case 101:
-            self->proc_func_ptr = XnoiseMidi_generate_aia;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_aia;
             break;
 
         case 110:
-            self->proc_func_ptr = XnoiseMidi_generate_iaa;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_iaa;
             break;
 
         case 111:
-            self->proc_func_ptr = XnoiseMidi_generate_aaa;
+            self->proc_func_ptr = (void (*)(void *))XnoiseMidi_generate_aaa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = XnoiseMidi_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseMidi_postprocessing_revareva;
             break;
     }
 }
@@ -4129,7 +4129,7 @@ XnoiseMidi_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->loopLen = (pyorand() % 10) + 3;
 
     Stream_setFunctionPtr(self->stream, XnoiseMidi_compute_next_data_frame);
-    self->mode_func_ptr = XnoiseMidi_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))XnoiseMidi_setProcMode;
 
     static char *kwlist[] = {"type", "freq", "x1", "x2", "scale", "range", "mul", "add", NULL};
 
@@ -4379,7 +4379,7 @@ typedef struct
     Stream *x2_stream;
     Stream *min_stream;
     Stream *max_stream;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     MYFLT xx1;
     MYFLT xx2;
     int type;
@@ -4728,55 +4728,55 @@ XnoiseDur_setRandomType(XnoiseDur *self)
     switch (self->type)
     {
         case 0:
-            self->type_func_ptr = XnoiseDur_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = XnoiseDur_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = XnoiseDur_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = XnoiseDur_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = XnoiseDur_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_expon_min;
             break;
 
         case 5:
-            self->type_func_ptr = XnoiseDur_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_expon_max;
             break;
 
         case 6:
-            self->type_func_ptr = XnoiseDur_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_biexpon;
             break;
 
         case 7:
-            self->type_func_ptr = XnoiseDur_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_cauchy;
             break;
 
         case 8:
-            self->type_func_ptr = XnoiseDur_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_weibull;
             break;
 
         case 9:
-            self->type_func_ptr = XnoiseDur_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_gaussian;
             break;
 
         case 10:
-            self->type_func_ptr = XnoiseDur_poisson;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_poisson;
             break;
 
         case 11:
-            self->type_func_ptr = XnoiseDur_walker;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_walker;
             break;
 
         case 12:
-            self->type_func_ptr = XnoiseDur_loopseg;
+            self->type_func_ptr = (MYFLT (*)(void *))XnoiseDur_loopseg;
             break;
     }
 }
@@ -4787,44 +4787,44 @@ XnoiseDur_setProcMode(XnoiseDur *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = XnoiseDur_generate;
+    self->proc_func_ptr = (void (*)(void *))XnoiseDur_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = XnoiseDur_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))XnoiseDur_postprocessing_revareva;
             break;
     }
 }
@@ -4910,7 +4910,7 @@ XnoiseDur_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->loopLen = (pyorand() % 10) + 3;
 
     Stream_setFunctionPtr(self->stream, XnoiseDur_compute_next_data_frame);
-    self->mode_func_ptr = XnoiseDur_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))XnoiseDur_setProcMode;
 
     static char *kwlist[] = {"type", "min", "max", "x1", "x2", "mul", "add", NULL};
 
@@ -5264,50 +5264,50 @@ Urn_setProcMode(Urn *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Urn_generate_i;
+            self->proc_func_ptr = (void (*)(void *))Urn_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Urn_generate_a;
+            self->proc_func_ptr = (void (*)(void *))Urn_generate_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Urn_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Urn_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Urn_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Urn_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Urn_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Urn_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Urn_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Urn_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Urn_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Urn_postprocessing_revareva;
             break;
     }
 }
@@ -5367,7 +5367,7 @@ Urn_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Urn_compute_next_data_frame);
-    self->mode_func_ptr = Urn_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Urn_setProcMode;
 
     static char *kwlist[] = {"max", "freq", "mul", "add", NULL};
 
@@ -5704,58 +5704,58 @@ LogiMap_setProcMode(LogiMap *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = LogiMap_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))LogiMap_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = LogiMap_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))LogiMap_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = LogiMap_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))LogiMap_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = LogiMap_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))LogiMap_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = LogiMap_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = LogiMap_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = LogiMap_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = LogiMap_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = LogiMap_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = LogiMap_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = LogiMap_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = LogiMap_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = LogiMap_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))LogiMap_postprocessing_revareva;
             break;
     }
 }
@@ -5813,7 +5813,7 @@ LogiMap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, LogiMap_compute_next_data_frame);
-    self->mode_func_ptr = LogiMap_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))LogiMap_setProcMode;
 
     static char *kwlist[] = {"chaos", "freq", "init", "mul", "add", NULL};
 

--- a/src/objects/recordmodule.c
+++ b/src/objects/recordmodule.c
@@ -86,7 +86,7 @@ Record_process(Record *self)
 static void
 Record_setProcMode(Record *self)
 {
-    self->proc_func_ptr = Record_process;
+    self->proc_func_ptr = (void (*)(void *))Record_process;
 }
 
 static void
@@ -142,7 +142,7 @@ Record_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Record_compute_next_data_frame);
-    self->mode_func_ptr = Record_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Record_setProcMode;
 
     static char *kwlist[] = {"input", "filename", "chnls", "fileformat", "sampletype", "buffering", "quality", NULL};
 
@@ -407,7 +407,7 @@ ControlRec_process(ControlRec *self)
 static void
 ControlRec_setProcMode(ControlRec *self)
 {
-    self->proc_func_ptr = ControlRec_process;
+    self->proc_func_ptr = (void (*)(void *))ControlRec_process;
 }
 
 static void
@@ -462,7 +462,7 @@ ControlRec_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, ControlRec_compute_next_data_frame);
-    self->mode_func_ptr = ControlRec_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ControlRec_setProcMode;
 
     static char *kwlist[] = {"input", "rate", "dur", NULL};
 
@@ -686,44 +686,44 @@ ControlRead_setProcMode(ControlRead *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = ControlRead_readframes_i;
+    self->proc_func_ptr = (void (*)(void *))ControlRead_readframes_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = ControlRead_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = ControlRead_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = ControlRead_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = ControlRead_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = ControlRead_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = ControlRead_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = ControlRead_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = ControlRead_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = ControlRead_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))ControlRead_postprocessing_revareva;
             break;
     }
 }
@@ -778,7 +778,7 @@ ControlRead_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, ControlRead_compute_next_data_frame);
-    self->mode_func_ptr = ControlRead_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))ControlRead_setProcMode;
 
     static char *kwlist[] = {"values", "rate", "loop", "interp", "mul", "add", NULL};
 
@@ -1061,7 +1061,7 @@ NoteinRec_process(NoteinRec *self)
 static void
 NoteinRec_setProcMode(NoteinRec *self)
 {
-    self->proc_func_ptr = NoteinRec_process;
+    self->proc_func_ptr = (void (*)(void *))NoteinRec_process;
 }
 
 static void
@@ -1122,7 +1122,7 @@ NoteinRec_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, NoteinRec_compute_next_data_frame);
-    self->mode_func_ptr = NoteinRec_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))NoteinRec_setProcMode;
 
     static char *kwlist[] = {"inputp", "inputv", NULL};
 
@@ -1316,44 +1316,44 @@ NoteinRead_setProcMode(NoteinRead *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = NoteinRead_readframes_i;
+    self->proc_func_ptr = (void (*)(void *))NoteinRead_readframes_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = NoteinRead_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = NoteinRead_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = NoteinRead_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = NoteinRead_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = NoteinRead_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = NoteinRead_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = NoteinRead_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = NoteinRead_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = NoteinRead_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))NoteinRead_postprocessing_revareva;
             break;
     }
 }
@@ -1407,7 +1407,7 @@ NoteinRead_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, NoteinRead_compute_next_data_frame);
-    self->mode_func_ptr = NoteinRead_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))NoteinRead_setProcMode;
 
     static char *kwlist[] = {"values", "timestamps", "loop", "mul", "add", NULL};
 

--- a/src/objects/selectmodule.c
+++ b/src/objects/selectmodule.c
@@ -74,44 +74,44 @@ Select_setProcMode(Select *self)
 
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Select_selector;
+    self->proc_func_ptr = (void (*)(void *))Select_selector;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Select_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Select_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Select_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Select_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Select_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Select_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Select_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Select_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Select_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Select_postprocessing_revareva;
             break;
     }
 
@@ -164,7 +164,7 @@ Select_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Select_compute_next_data_frame);
-    self->mode_func_ptr = Select_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Select_setProcMode;
 
     static char *kwlist[] = {"input", "value", "mul", "add", NULL};
 
@@ -374,44 +374,44 @@ Change_setProcMode(Change *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Change_selector;
+    self->proc_func_ptr = (void (*)(void *))Change_selector;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Change_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Change_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Change_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Change_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Change_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Change_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Change_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Change_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Change_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Change_postprocessing_revareva;
             break;
     }
 }
@@ -462,7 +462,7 @@ Change_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Change_compute_next_data_frame);
-    self->mode_func_ptr = Change_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Change_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 

--- a/src/objects/sfplayermodule.c
+++ b/src/objects/sfplayermodule.c
@@ -290,7 +290,7 @@ SfPlayer_readframes_i(SfPlayer *self)
 static void
 SfPlayer_setProcMode(SfPlayer *self)
 {
-    self->proc_func_ptr = SfPlayer_readframes_i;
+    self->proc_func_ptr = (void (*)(void *))SfPlayer_readframes_i;
 }
 
 static void
@@ -349,7 +349,7 @@ SfPlayer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfPlayer_compute_next_data_frame);
-    self->mode_func_ptr = SfPlayer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfPlayer_setProcMode;
 
     static char *kwlist[] = {"path", "speed", "loop", "offset", "interp", NULL};
 
@@ -606,39 +606,39 @@ SfPlay_setProcMode(SfPlay *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SfPlay_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SfPlay_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SfPlay_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SfPlay_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SfPlay_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SfPlay_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SfPlay_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SfPlay_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SfPlay_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SfPlay_postprocessing_revareva;
             break;
     }
 }
@@ -698,7 +698,7 @@ SfPlay_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfPlay_compute_next_data_frame);
-    self->mode_func_ptr = SfPlay_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfPlay_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", "mul", "add", NULL};
 
@@ -875,7 +875,7 @@ typedef struct
     MYFLT *markers;
     int markers_size;
     MYFLT x;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     MYFLT (*interp_func_ptr)(MYFLT *, T_SIZE_T, MYFLT, T_SIZE_T);
 } SfMarkerShuffler;
 
@@ -1213,7 +1213,7 @@ SfMarkerShuffler_readframes_i(SfMarkerShuffler *self)
 static void
 SfMarkerShuffler_setProcMode(SfMarkerShuffler *self)
 {
-    self->proc_func_ptr = SfMarkerShuffler_readframes_i;
+    self->proc_func_ptr = (void (*)(void *))SfMarkerShuffler_readframes_i;
 }
 
 static void
@@ -1340,7 +1340,7 @@ SfMarkerShuffler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->x = 0.5;
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfMarkerShuffler_compute_next_data_frame);
-    self->mode_func_ptr = SfMarkerShuffler_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfMarkerShuffler_setProcMode;
 
     static char *kwlist[] = {"path", "speed", "interp", NULL};
 
@@ -1356,7 +1356,7 @@ SfMarkerShuffler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     (*self->mode_func_ptr)(self);
 
-    self->type_func_ptr = SfMarkerShuffler_uniform;
+    self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_uniform;
 
     if (self->interp == 0)
         self->interp = 2;
@@ -1454,49 +1454,49 @@ SfMarkerShuffler_setRandomType(SfMarkerShuffler *self, PyObject *args, PyObject 
     switch (dist)
     {
         case 0:
-            self->type_func_ptr = SfMarkerShuffler_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = SfMarkerShuffler_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = SfMarkerShuffler_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = SfMarkerShuffler_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = SfMarkerShuffler_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_expon_min;
             self->x *= 10.0;
             break;
 
         case 5:
-            self->type_func_ptr = SfMarkerShuffler_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_expon_max;
             self->x *= 10.0;
             break;
 
         case 6:
-            self->type_func_ptr = SfMarkerShuffler_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_biexpon;
             self->x *= 10.0;
             break;
 
         case 7:
-            self->type_func_ptr = SfMarkerShuffler_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_cauchy;
             self->x *= 10.0;
             self->x = 10.0 - self->x;
             break;
 
         case 8:
-            self->type_func_ptr = SfMarkerShuffler_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_weibull;
             self->x = self->x * 5.0 + 0.1;
             break;
 
         case 9:
-            self->type_func_ptr = SfMarkerShuffler_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))SfMarkerShuffler_gaussian;
             self->x *= 10.0;
             self->x = 10.0 - self->x;
             break;
@@ -1621,39 +1621,39 @@ SfMarkerShuffle_setProcMode(SfMarkerShuffle *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SfMarkerShuffle_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerShuffle_postprocessing_revareva;
             break;
     }
 }
@@ -1713,7 +1713,7 @@ SfMarkerShuffle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfMarkerShuffle_compute_next_data_frame);
-    self->mode_func_ptr = SfMarkerShuffle_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfMarkerShuffle_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", "mul", "add", NULL};
 
@@ -2091,7 +2091,7 @@ SfMarkerLooper_readframes_i(SfMarkerLooper *self)
 static void
 SfMarkerLooper_setProcMode(SfMarkerLooper *self)
 {
-    self->proc_func_ptr = SfMarkerLooper_readframes_i;
+    self->proc_func_ptr = (void (*)(void *))SfMarkerLooper_readframes_i;
 }
 
 static void
@@ -2233,7 +2233,7 @@ SfMarkerLooper_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfMarkerLooper_compute_next_data_frame);
-    self->mode_func_ptr = SfMarkerLooper_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfMarkerLooper_setProcMode;
 
     static char *kwlist[] = {"path", "speed", "mark", "interp", NULL};
 
@@ -2442,39 +2442,39 @@ SfMarkerLoop_setProcMode(SfMarkerLoop *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SfMarkerLoop_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SfMarkerLoop_postprocessing_revareva;
             break;
     }
 }
@@ -2534,7 +2534,7 @@ SfMarkerLoop_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SfMarkerLoop_compute_next_data_frame);
-    self->mode_func_ptr = SfMarkerLoop_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SfMarkerLoop_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", "chnl", "mul", "add", NULL};
 

--- a/src/objects/sigmodule.c
+++ b/src/objects/sigmodule.c
@@ -52,39 +52,39 @@ Sig_setProcMode(Sig *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Sig_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Sig_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Sig_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Sig_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Sig_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Sig_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Sig_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Sig_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Sig_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Sig_postprocessing_revareva;
             break;
     }
 }
@@ -156,7 +156,7 @@ Sig_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Sig_compute_next_data_frame);
-    self->mode_func_ptr = Sig_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Sig_setProcMode;
 
     static char *kwlist[] = {"value", "mul", "add", NULL};
 
@@ -443,44 +443,44 @@ SigTo_setProcMode(SigTo *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = SigTo_generates_i;
+    self->proc_func_ptr = (void (*)(void *))SigTo_generates_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SigTo_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SigTo_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SigTo_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SigTo_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SigTo_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SigTo_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SigTo_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SigTo_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SigTo_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SigTo_postprocessing_revareva;
             break;
     }
 }
@@ -540,7 +540,7 @@ SigTo_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SigTo_compute_next_data_frame);
-    self->mode_func_ptr = SigTo_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SigTo_setProcMode;
 
     static char *kwlist[] = {"value", "time", "init", "mul", "add", NULL};
 
@@ -811,44 +811,44 @@ VarPort_setProcMode(VarPort *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = VarPort_generates_i;
+    self->proc_func_ptr = (void (*)(void *))VarPort_generates_i;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = VarPort_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = VarPort_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = VarPort_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = VarPort_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = VarPort_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = VarPort_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = VarPort_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = VarPort_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = VarPort_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))VarPort_postprocessing_revareva;
             break;
     }
 }
@@ -910,7 +910,7 @@ VarPort_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, VarPort_compute_next_data_frame);
-    self->mode_func_ptr = VarPort_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))VarPort_setProcMode;
 
     static char *kwlist[] = {"value", "time", "init", "callable", "arg", "mul", "add", NULL};
 

--- a/src/objects/tablemodule.c
+++ b/src/objects/tablemodule.c
@@ -6460,39 +6460,39 @@ TableRecTimeStream_setProcMode(TableRecTimeStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TableRecTimeStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TableRecTimeStream_postprocessing_revareva;
             break;
     }
 }
@@ -6550,7 +6550,7 @@ TableRecTimeStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TableRecTimeStream_compute_next_data_frame);
-    self->mode_func_ptr = TableRecTimeStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TableRecTimeStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", NULL};
 
@@ -7289,39 +7289,39 @@ TrigTableRecTimeStream_setProcMode(TrigTableRecTimeStream *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigTableRecTimeStream_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigTableRecTimeStream_postprocessing_revareva;
             break;
     }
 }
@@ -7379,7 +7379,7 @@ TrigTableRecTimeStream_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigTableRecTimeStream_compute_next_data_frame);
-    self->mode_func_ptr = TrigTableRecTimeStream_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigTableRecTimeStream_setProcMode;
 
     static char *kwlist[] = {"mainPlayer", NULL};
 

--- a/src/objects/trigmodule.c
+++ b/src/objects/trigmodule.c
@@ -90,50 +90,50 @@ TrigRandInt_setProcMode(TrigRandInt *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigRandInt_generate_i;
+            self->proc_func_ptr = (void (*)(void *))TrigRandInt_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigRandInt_generate_a;
+            self->proc_func_ptr = (void (*)(void *))TrigRandInt_generate_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigRandInt_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRandInt_postprocessing_revareva;
             break;
     }
 }
@@ -189,7 +189,7 @@ TrigRandInt_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigRandInt_compute_next_data_frame);
-    self->mode_func_ptr = TrigRandInt_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigRandInt_setProcMode;
 
     static char *kwlist[] = {"input", "max", "mul", "add", NULL};
 
@@ -546,58 +546,58 @@ TrigRand_setProcMode(TrigRand *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigRand_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))TrigRand_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigRand_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))TrigRand_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = TrigRand_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))TrigRand_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = TrigRand_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))TrigRand_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigRand_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigRand_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigRand_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigRand_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigRand_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigRand_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigRand_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigRand_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigRand_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigRand_postprocessing_revareva;
             break;
     }
 }
@@ -660,7 +660,7 @@ TrigRand_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigRand_compute_next_data_frame);
-    self->mode_func_ptr = TrigRand_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigRand_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "port", "init", "mul", "add", NULL};
 
@@ -916,44 +916,44 @@ TrigChoice_setProcMode(TrigChoice *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TrigChoice_generate;
+    self->proc_func_ptr = (void (*)(void *))TrigChoice_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigChoice_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigChoice_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigChoice_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigChoice_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigChoice_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigChoice_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigChoice_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigChoice_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigChoice_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigChoice_postprocessing_revareva;
             break;
     }
 }
@@ -1009,7 +1009,7 @@ TrigChoice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigChoice_compute_next_data_frame);
-    self->mode_func_ptr = TrigChoice_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigChoice_setProcMode;
 
     static char *kwlist[] = {"input", "choice", "port", "init", "mul", "add", NULL};
 
@@ -1579,50 +1579,50 @@ TrigEnv_setProcMode(TrigEnv *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigEnv_readframes_i;
+            self->proc_func_ptr = (void (*)(void *))TrigEnv_readframes_i;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigEnv_readframes_a;
+            self->proc_func_ptr = (void (*)(void *))TrigEnv_readframes_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigEnv_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigEnv_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigEnv_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigEnv_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigEnv_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigEnv_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigEnv_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigEnv_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigEnv_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigEnv_postprocessing_revareva;
             break;
     }
 }
@@ -1681,7 +1681,7 @@ TrigEnv_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigEnv_compute_next_data_frame);
-    self->mode_func_ptr = TrigEnv_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigEnv_setProcMode;
 
     self->dur = PyFloat_FromDouble(1.);
     self->current_dur = self->sr;
@@ -2017,44 +2017,44 @@ TrigLinseg_setProcMode(TrigLinseg *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TrigLinseg_generate;
+    self->proc_func_ptr = (void (*)(void *))TrigLinseg_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigLinseg_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigLinseg_postprocessing_revareva;
             break;
     }
 }
@@ -2111,7 +2111,7 @@ TrigLinseg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigLinseg_compute_next_data_frame);
-    self->mode_func_ptr = TrigLinseg_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigLinseg_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -2447,44 +2447,44 @@ TrigExpseg_setProcMode(TrigExpseg *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TrigExpseg_generate;
+    self->proc_func_ptr = (void (*)(void *))TrigExpseg_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigExpseg_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigExpseg_postprocessing_revareva;
             break;
     }
 }
@@ -2543,7 +2543,7 @@ TrigExpseg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigExpseg_compute_next_data_frame);
-    self->mode_func_ptr = TrigExpseg_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigExpseg_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
 
@@ -2770,7 +2770,7 @@ typedef struct
     PyObject *x2;
     Stream *x1_stream;
     Stream *x2_stream;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     MYFLT xx1;
     MYFLT xx2;
     int type;
@@ -3144,55 +3144,55 @@ TrigXnoise_setRandomType(TrigXnoise *self)
     switch (self->type)
     {
         case 0:
-            self->type_func_ptr = TrigXnoise_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = TrigXnoise_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = TrigXnoise_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = TrigXnoise_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = TrigXnoise_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_expon_min;
             break;
 
         case 5:
-            self->type_func_ptr = TrigXnoise_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_expon_max;
             break;
 
         case 6:
-            self->type_func_ptr = TrigXnoise_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_biexpon;
             break;
 
         case 7:
-            self->type_func_ptr = TrigXnoise_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_cauchy;
             break;
 
         case 8:
-            self->type_func_ptr = TrigXnoise_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_weibull;
             break;
 
         case 9:
-            self->type_func_ptr = TrigXnoise_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_gaussian;
             break;
 
         case 10:
-            self->type_func_ptr = TrigXnoise_poisson;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_poisson;
             break;
 
         case 11:
-            self->type_func_ptr = TrigXnoise_walker;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_walker;
             break;
 
         case 12:
-            self->type_func_ptr = TrigXnoise_loopseg;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoise_loopseg;
             break;
     }
 }
@@ -3207,58 +3207,58 @@ TrigXnoise_setProcMode(TrigXnoise *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigXnoise_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoise_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigXnoise_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoise_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = TrigXnoise_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoise_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = TrigXnoise_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoise_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigXnoise_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoise_postprocessing_revareva;
             break;
     }
 }
@@ -3337,7 +3337,7 @@ TrigXnoise_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->loopLen = (pyorand() % 10) + 3;
 
     Stream_setFunctionPtr(self->stream, TrigXnoise_compute_next_data_frame);
-    self->mode_func_ptr = TrigXnoise_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigXnoise_setProcMode;
 
     static char *kwlist[] = {"input", "type", "x1", "x2", "mul", "add", NULL};
 
@@ -3533,7 +3533,7 @@ typedef struct
     PyObject *x2;
     Stream *x1_stream;
     Stream *x2_stream;
-    MYFLT (*type_func_ptr)();
+    MYFLT (*type_func_ptr)(void *);
     int scale; // 0 = Midi, 1 = frequency, 2 = transpo
     int range_min;
     int range_max;
@@ -3943,55 +3943,55 @@ TrigXnoiseMidi_setRandomType(TrigXnoiseMidi *self)
     switch (self->type)
     {
         case 0:
-            self->type_func_ptr = TrigXnoiseMidi_uniform;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_uniform;
             break;
 
         case 1:
-            self->type_func_ptr = TrigXnoiseMidi_linear_min;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_linear_min;
             break;
 
         case 2:
-            self->type_func_ptr = TrigXnoiseMidi_linear_max;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_linear_max;
             break;
 
         case 3:
-            self->type_func_ptr = TrigXnoiseMidi_triangle;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_triangle;
             break;
 
         case 4:
-            self->type_func_ptr = TrigXnoiseMidi_expon_min;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_expon_min;
             break;
 
         case 5:
-            self->type_func_ptr = TrigXnoiseMidi_expon_max;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_expon_max;
             break;
 
         case 6:
-            self->type_func_ptr = TrigXnoiseMidi_biexpon;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_biexpon;
             break;
 
         case 7:
-            self->type_func_ptr = TrigXnoiseMidi_cauchy;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_cauchy;
             break;
 
         case 8:
-            self->type_func_ptr = TrigXnoiseMidi_weibull;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_weibull;
             break;
 
         case 9:
-            self->type_func_ptr = TrigXnoiseMidi_gaussian;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_gaussian;
             break;
 
         case 10:
-            self->type_func_ptr = TrigXnoiseMidi_poisson;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_poisson;
             break;
 
         case 11:
-            self->type_func_ptr = TrigXnoiseMidi_walker;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_walker;
             break;
 
         case 12:
-            self->type_func_ptr = TrigXnoiseMidi_loopseg;
+            self->type_func_ptr = (MYFLT (*)(void *))TrigXnoiseMidi_loopseg;
             break;
     }
 }
@@ -4006,58 +4006,58 @@ TrigXnoiseMidi_setProcMode(TrigXnoiseMidi *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigXnoiseMidi_generate_ii;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoiseMidi_generate_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigXnoiseMidi_generate_ai;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoiseMidi_generate_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = TrigXnoiseMidi_generate_ia;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoiseMidi_generate_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = TrigXnoiseMidi_generate_aa;
+            self->proc_func_ptr = (void (*)(void *))TrigXnoiseMidi_generate_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigXnoiseMidi_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigXnoiseMidi_postprocessing_revareva;
             break;
     }
 }
@@ -4140,7 +4140,7 @@ TrigXnoiseMidi_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->loopLen = (pyorand() % 10) + 3;
 
     Stream_setFunctionPtr(self->stream, TrigXnoiseMidi_compute_next_data_frame);
-    self->mode_func_ptr = TrigXnoiseMidi_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigXnoiseMidi_setProcMode;
 
     static char *kwlist[] = {"input", "type", "x1", "x2", "scale", "range", "mul", "add", NULL};
 
@@ -4452,44 +4452,44 @@ Counter_setProcMode(Counter *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Counter_generates;
+    self->proc_func_ptr = (void (*)(void *))Counter_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Counter_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Counter_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Counter_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Counter_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Counter_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Counter_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Counter_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Counter_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Counter_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Counter_postprocessing_revareva;
             break;
     }
 }
@@ -4543,7 +4543,7 @@ Counter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Counter_compute_next_data_frame);
-    self->mode_func_ptr = Counter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Counter_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "dir", "mul", "add", NULL};
 
@@ -4920,50 +4920,50 @@ Thresh_setProcMode(Thresh *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Thresh_generates_i;
+            self->proc_func_ptr = (void (*)(void *))Thresh_generates_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Thresh_generates_a;
+            self->proc_func_ptr = (void (*)(void *))Thresh_generates_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Thresh_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Thresh_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Thresh_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Thresh_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Thresh_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Thresh_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Thresh_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Thresh_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Thresh_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Thresh_postprocessing_revareva;
             break;
     }
 }
@@ -5019,7 +5019,7 @@ Thresh_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Thresh_compute_next_data_frame);
-    self->mode_func_ptr = Thresh_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Thresh_setProcMode;
 
     static char *kwlist[] = {"input", "threshold", "dir", "mul", "add", NULL};
 
@@ -5268,50 +5268,50 @@ Percent_setProcMode(Percent *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Percent_generates_i;
+            self->proc_func_ptr = (void (*)(void *))Percent_generates_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Percent_generates_a;
+            self->proc_func_ptr = (void (*)(void *))Percent_generates_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Percent_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Percent_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Percent_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Percent_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Percent_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Percent_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Percent_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Percent_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Percent_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Percent_postprocessing_revareva;
             break;
     }
 }
@@ -5365,7 +5365,7 @@ Percent_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Percent_compute_next_data_frame);
-    self->mode_func_ptr = Percent_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Percent_setProcMode;
 
     static char *kwlist[] = {"input", "percent", "mul", "add", NULL};
 
@@ -5585,44 +5585,44 @@ Timer_setProcMode(Timer *self)
 {
     int muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Timer_generates;
+    self->proc_func_ptr = (void (*)(void *))Timer_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Timer_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Timer_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Timer_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Timer_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Timer_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Timer_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Timer_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Timer_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Timer_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Timer_postprocessing_revareva;
             break;
     }
 }
@@ -5677,7 +5677,7 @@ Timer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Timer_compute_next_data_frame);
-    self->mode_func_ptr = Timer_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Timer_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "mul", "add", NULL};
 
@@ -5924,44 +5924,44 @@ Iter_setProcMode(Iter *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Iter_generate;
+    self->proc_func_ptr = (void (*)(void *))Iter_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Iter_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Iter_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Iter_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Iter_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Iter_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Iter_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Iter_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Iter_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Iter_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Iter_postprocessing_revareva;
             break;
     }
 }
@@ -6021,7 +6021,7 @@ Iter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Iter_compute_next_data_frame);
-    self->mode_func_ptr = Iter_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Iter_setProcMode;
 
     static char *kwlist[] = {"input", "choice", "init", "mul", "add", NULL};
 
@@ -6286,44 +6286,44 @@ Count_setProcMode(Count *self)
 {
     int muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Count_generates;
+    self->proc_func_ptr = (void (*)(void *))Count_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Count_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Count_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Count_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Count_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Count_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Count_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Count_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Count_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Count_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Count_postprocessing_revareva;
             break;
     }
 }
@@ -6377,7 +6377,7 @@ Count_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Count_compute_next_data_frame);
-    self->mode_func_ptr = Count_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Count_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "mul", "add", NULL};
 
@@ -6598,44 +6598,44 @@ NextTrig_setProcMode(NextTrig *self)
 {
     int muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = NextTrig_generates;
+    self->proc_func_ptr = (void (*)(void *))NextTrig_generates;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = NextTrig_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = NextTrig_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = NextTrig_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = NextTrig_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = NextTrig_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = NextTrig_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = NextTrig_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = NextTrig_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = NextTrig_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))NextTrig_postprocessing_revareva;
             break;
     }
 }
@@ -6688,7 +6688,7 @@ NextTrig_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, NextTrig_compute_next_data_frame);
-    self->mode_func_ptr = NextTrig_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))NextTrig_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "mul", "add", NULL};
 
@@ -6906,50 +6906,50 @@ TrigVal_setProcMode(TrigVal *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrigVal_generate_i;
+            self->proc_func_ptr = (void (*)(void *))TrigVal_generate_i;
             break;
 
         case 1:
-            self->proc_func_ptr = TrigVal_generate_a;
+            self->proc_func_ptr = (void (*)(void *))TrigVal_generate_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrigVal_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrigVal_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrigVal_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrigVal_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrigVal_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrigVal_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrigVal_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrigVal_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrigVal_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrigVal_postprocessing_revareva;
             break;
     }
 }
@@ -7004,7 +7004,7 @@ TrigVal_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrigVal_compute_next_data_frame);
-    self->mode_func_ptr = TrigVal_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrigVal_setProcMode;
 
     static char *kwlist[] = {"input", "value", "init", "mul", "add", NULL};
 

--- a/src/objects/utilsmodule.c
+++ b/src/objects/utilsmodule.c
@@ -97,11 +97,11 @@ Print_setProcMode(Print *self)
     switch (self->method)
     {
         case 0:
-            self->proc_func_ptr = Print_process_time;
+            self->proc_func_ptr = (void (*)(void *))Print_process_time;
             break;
 
         case 1:
-            self->proc_func_ptr = Print_process_change;
+            self->proc_func_ptr = (void (*)(void *))Print_process_change;
             break;
     }
 }
@@ -151,7 +151,7 @@ Print_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Print_compute_next_data_frame);
-    self->mode_func_ptr = Print_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Print_setProcMode;
 
     self->sampleToSec = 1. / self->sr;
     self->currentTime = 0.;
@@ -367,44 +367,44 @@ Snap_setProcMode(Snap *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Snap_generate;
+    self->proc_func_ptr = (void (*)(void *))Snap_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Snap_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Snap_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Snap_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Snap_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Snap_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Snap_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Snap_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Snap_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Snap_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Snap_postprocessing_revareva;
             break;
     }
 }
@@ -458,7 +458,7 @@ Snap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Snap_compute_next_data_frame);
-    self->mode_func_ptr = Snap_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Snap_setProcMode;
 
     static char *kwlist[] = {"input", "choice", "scale", "mul", "add", NULL};
 
@@ -747,50 +747,50 @@ Interp_setProcMode(Interp *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Interp_filters_i;
+            self->proc_func_ptr = (void (*)(void *))Interp_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Interp_filters_a;
+            self->proc_func_ptr = (void (*)(void *))Interp_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Interp_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Interp_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Interp_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Interp_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Interp_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Interp_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Interp_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Interp_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Interp_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Interp_postprocessing_revareva;
             break;
     }
 }
@@ -846,7 +846,7 @@ Interp_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Interp_compute_next_data_frame);
-    self->mode_func_ptr = Interp_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Interp_setProcMode;
 
     static char *kwlist[] = {"input", "input2", "interp", "mul", "add", NULL};
 
@@ -1106,50 +1106,50 @@ SampHold_setProcMode(SampHold *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = SampHold_filters_i;
+            self->proc_func_ptr = (void (*)(void *))SampHold_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = SampHold_filters_a;
+            self->proc_func_ptr = (void (*)(void *))SampHold_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = SampHold_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = SampHold_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = SampHold_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = SampHold_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = SampHold_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = SampHold_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = SampHold_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = SampHold_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = SampHold_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))SampHold_postprocessing_revareva;
             break;
     }
 }
@@ -1207,7 +1207,7 @@ SampHold_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, SampHold_compute_next_data_frame);
-    self->mode_func_ptr = SampHold_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))SampHold_setProcMode;
 
     static char *kwlist[] = {"input", "controlsig", "value", "mul", "add", NULL};
 
@@ -1473,50 +1473,50 @@ TrackHold_setProcMode(TrackHold *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = TrackHold_filters_i;
+            self->proc_func_ptr = (void (*)(void *))TrackHold_filters_i;
             break;
 
         case 1:
-            self->proc_func_ptr = TrackHold_filters_a;
+            self->proc_func_ptr = (void (*)(void *))TrackHold_filters_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TrackHold_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TrackHold_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TrackHold_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TrackHold_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TrackHold_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TrackHold_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TrackHold_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TrackHold_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TrackHold_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TrackHold_postprocessing_revareva;
             break;
     }
 }
@@ -1574,7 +1574,7 @@ TrackHold_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TrackHold_compute_next_data_frame);
-    self->mode_func_ptr = TrackHold_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TrackHold_setProcMode;
 
     static char *kwlist[] = {"input", "controlsig", "value", "mul", "add", NULL};
 
@@ -1842,50 +1842,50 @@ Compare_setProcMode(Compare *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Compare_process_i;
+            self->proc_func_ptr = (void (*)(void *))Compare_process_i;
             break;
 
         case 1:
-            self->proc_func_ptr = Compare_process_a;
+            self->proc_func_ptr = (void (*)(void *))Compare_process_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Compare_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Compare_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Compare_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Compare_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Compare_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Compare_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Compare_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Compare_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Compare_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Compare_postprocessing_revareva;
             break;
     }
 }
@@ -1941,7 +1941,7 @@ Compare_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Compare_compute_next_data_frame);
-    self->mode_func_ptr = Compare_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Compare_setProcMode;
 
     static char *kwlist[] = {"input", "comp", "mode", "mul", "add", NULL};
 
@@ -2249,58 +2249,58 @@ Between_setProcMode(Between *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = Between_transform_ii;
+            self->proc_func_ptr = (void (*)(void *))Between_transform_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = Between_transform_ai;
+            self->proc_func_ptr = (void (*)(void *))Between_transform_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = Between_transform_ia;
+            self->proc_func_ptr = (void (*)(void *))Between_transform_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = Between_transform_aa;
+            self->proc_func_ptr = (void (*)(void *))Between_transform_aa;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Between_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Between_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Between_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Between_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Between_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Between_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Between_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Between_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Between_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Between_postprocessing_revareva;
             break;
     }
 }
@@ -2358,7 +2358,7 @@ Between_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Between_compute_next_data_frame);
-    self->mode_func_ptr = Between_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Between_setProcMode;
 
     static char *kwlist[] = {"input", "min", "max", "mul", "add", NULL};
 
@@ -2571,44 +2571,44 @@ Denorm_setProcMode(Denorm *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Denorm_filters;
+    self->proc_func_ptr = (void (*)(void *))Denorm_filters;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Denorm_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Denorm_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Denorm_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Denorm_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Denorm_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Denorm_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Denorm_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Denorm_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Denorm_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Denorm_postprocessing_revareva;
             break;
     }
 }
@@ -2658,7 +2658,7 @@ Denorm_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Denorm_compute_next_data_frame);
-    self->mode_func_ptr = Denorm_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Denorm_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -2865,44 +2865,44 @@ DBToA_setProcMode(DBToA *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = DBToA_process;
+    self->proc_func_ptr = (void (*)(void *))DBToA_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = DBToA_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = DBToA_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = DBToA_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = DBToA_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = DBToA_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = DBToA_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = DBToA_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = DBToA_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = DBToA_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))DBToA_postprocessing_revareva;
             break;
     }
 }
@@ -2954,7 +2954,7 @@ DBToA_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, DBToA_compute_next_data_frame);
-    self->mode_func_ptr = DBToA_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))DBToA_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3159,44 +3159,44 @@ AToDB_setProcMode(AToDB *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = AToDB_process;
+    self->proc_func_ptr = (void (*)(void *))AToDB_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = AToDB_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = AToDB_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = AToDB_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = AToDB_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = AToDB_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = AToDB_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = AToDB_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = AToDB_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = AToDB_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))AToDB_postprocessing_revareva;
             break;
     }
 }
@@ -3248,7 +3248,7 @@ AToDB_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, AToDB_compute_next_data_frame);
-    self->mode_func_ptr = AToDB_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))AToDB_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -3592,44 +3592,44 @@ Scale_setProcMode(Scale *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Scale_generate;
+    self->proc_func_ptr = (void (*)(void *))Scale_generate;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Scale_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Scale_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Scale_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Scale_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Scale_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Scale_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Scale_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Scale_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Scale_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Scale_postprocessing_revareva;
             break;
     }
 }
@@ -3699,7 +3699,7 @@ Scale_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Scale_compute_next_data_frame);
-    self->mode_func_ptr = Scale_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Scale_setProcMode;
 
     static char *kwlist[] = {"input", "inmin", "inmax", "outmin", "outmax", "exp", "mul", "add", NULL};
 
@@ -3935,44 +3935,44 @@ CentsToTranspo_setProcMode(CentsToTranspo *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = CentsToTranspo_process;
+    self->proc_func_ptr = (void (*)(void *))CentsToTranspo_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = CentsToTranspo_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))CentsToTranspo_postprocessing_revareva;
             break;
     }
 }
@@ -4024,7 +4024,7 @@ CentsToTranspo_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, CentsToTranspo_compute_next_data_frame);
-    self->mode_func_ptr = CentsToTranspo_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))CentsToTranspo_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -4224,44 +4224,44 @@ TranspoToCents_setProcMode(TranspoToCents *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = TranspoToCents_process;
+    self->proc_func_ptr = (void (*)(void *))TranspoToCents_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = TranspoToCents_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))TranspoToCents_postprocessing_revareva;
             break;
     }
 }
@@ -4313,7 +4313,7 @@ TranspoToCents_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, TranspoToCents_compute_next_data_frame);
-    self->mode_func_ptr = TranspoToCents_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))TranspoToCents_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -4521,44 +4521,44 @@ MToF_setProcMode(MToF *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MToF_process;
+    self->proc_func_ptr = (void (*)(void *))MToF_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MToF_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MToF_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MToF_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MToF_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MToF_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MToF_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MToF_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MToF_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MToF_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MToF_postprocessing_revareva;
             break;
     }
 }
@@ -4610,7 +4610,7 @@ MToF_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MToF_compute_next_data_frame);
-    self->mode_func_ptr = MToF_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MToF_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -4813,44 +4813,44 @@ FToM_setProcMode(FToM *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = FToM_process;
+    self->proc_func_ptr = (void (*)(void *))FToM_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = FToM_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = FToM_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = FToM_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = FToM_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = FToM_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = FToM_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = FToM_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = FToM_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = FToM_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))FToM_postprocessing_revareva;
             break;
     }
 }
@@ -4902,7 +4902,7 @@ FToM_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, FToM_compute_next_data_frame);
-    self->mode_func_ptr = FToM_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))FToM_setProcMode;
 
     static char *kwlist[] = {"input", "mul", "add", NULL};
 
@@ -5103,44 +5103,44 @@ MToT_setProcMode(MToT *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = MToT_process;
+    self->proc_func_ptr = (void (*)(void *))MToT_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = MToT_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = MToT_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = MToT_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = MToT_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = MToT_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = MToT_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = MToT_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = MToT_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = MToT_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))MToT_postprocessing_revareva;
             break;
     }
 }
@@ -5193,7 +5193,7 @@ MToT_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, MToT_compute_next_data_frame);
-    self->mode_func_ptr = MToT_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))MToT_setProcMode;
 
     static char *kwlist[] = {"input", "centralkey", "mul", "add", NULL};
 
@@ -5598,44 +5598,44 @@ Resample_setProcMode(Resample *self)
     int muladdmode;
     muladdmode = self->modebuffer[0] + self->modebuffer[1] * 10;
 
-    self->proc_func_ptr = Resample_process;
+    self->proc_func_ptr = (void (*)(void *))Resample_process;
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = Resample_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = Resample_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = Resample_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = Resample_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = Resample_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = Resample_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = Resample_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = Resample_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = Resample_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))Resample_postprocessing_revareva;
             break;
     }
 }
@@ -5704,7 +5704,7 @@ Resample_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, Resample_compute_next_data_frame);
-    self->mode_func_ptr = Resample_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))Resample_setProcMode;
 
     static char *kwlist[] = {"input", "mode", "mul", "add", NULL};
 

--- a/src/objects/wgverbmodule.c
+++ b/src/objects/wgverbmodule.c
@@ -54,7 +54,7 @@ typedef struct
     Stream *cutoff_stream;
     PyObject *mix;
     Stream *mix_stream;
-    void (*mix_func_ptr)();
+    void (*mix_func_ptr)(void *);
     int modebuffer[5];
     MYFLT total_signal;
     MYFLT delays[8];
@@ -445,69 +445,69 @@ WGVerb_setProcMode(WGVerb *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = WGVerb_process_ii;
+            self->proc_func_ptr = (void (*)(void *))WGVerb_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = WGVerb_process_ai;
+            self->proc_func_ptr = (void (*)(void *))WGVerb_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = WGVerb_process_ia;
+            self->proc_func_ptr = (void (*)(void *))WGVerb_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = WGVerb_process_aa;
+            self->proc_func_ptr = (void (*)(void *))WGVerb_process_aa;
             break;
     }
 
     switch (mixmode)
     {
         case 0:
-            self->mix_func_ptr = WGVerb_mix_i;
+            self->mix_func_ptr = (void (*)(void *))WGVerb_mix_i;
             break;
 
         case 1:
-            self->mix_func_ptr = WGVerb_mix_a;
+            self->mix_func_ptr = (void (*)(void *))WGVerb_mix_a;
             break;
     }
 
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = WGVerb_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = WGVerb_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = WGVerb_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = WGVerb_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = WGVerb_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = WGVerb_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = WGVerb_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = WGVerb_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = WGVerb_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))WGVerb_postprocessing_revareva;
             break;
     }
 }
@@ -580,7 +580,7 @@ WGVerb_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, WGVerb_compute_next_data_frame);
-    self->mode_func_ptr = WGVerb_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))WGVerb_setProcMode;
 
     for (i = 0; i < 8; i++)
     {
@@ -816,7 +816,7 @@ typedef struct
     Stream *cutoff_stream;
     PyObject *mix;
     Stream *mix_stream;
-    void (*mix_func_ptr)();
+    void (*mix_func_ptr)(void *);
     int modebuffer[4];
     MYFLT firstRefGain;
     MYFLT total_signal[2];
@@ -1518,30 +1518,30 @@ STReverb_setProcMode(STReverb *self)
     switch (procmode)
     {
         case 0:
-            self->proc_func_ptr = STReverb_process_ii;
+            self->proc_func_ptr = (void (*)(void *))STReverb_process_ii;
             break;
 
         case 1:
-            self->proc_func_ptr = STReverb_process_ai;
+            self->proc_func_ptr = (void (*)(void *))STReverb_process_ai;
             break;
 
         case 10:
-            self->proc_func_ptr = STReverb_process_ia;
+            self->proc_func_ptr = (void (*)(void *))STReverb_process_ia;
             break;
 
         case 11:
-            self->proc_func_ptr = STReverb_process_aa;
+            self->proc_func_ptr = (void (*)(void *))STReverb_process_aa;
             break;
     }
 
     switch (mixmode)
     {
         case 0:
-            self->mix_func_ptr = STReverb_mix_i;
+            self->mix_func_ptr = (void (*)(void *))STReverb_mix_i;
             break;
 
         case 1:
-            self->mix_func_ptr = STReverb_mix_a;
+            self->mix_func_ptr = (void (*)(void *))STReverb_mix_a;
             break;
     }
 }
@@ -1638,7 +1638,7 @@ STReverb_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->srfac = self->sr / 44100.0;
 
     Stream_setFunctionPtr(self->stream, STReverb_compute_next_data_frame);
-    self->mode_func_ptr = STReverb_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))STReverb_setProcMode;
 
     static char *kwlist[] = {"input", "inpos", "revtime", "cutoff", "mix", "roomSize", "firstRefGain", NULL};
 
@@ -1976,39 +1976,39 @@ STRev_setProcMode(STRev *self)
     switch (muladdmode)
     {
         case 0:
-            self->muladd_func_ptr = STRev_postprocessing_ii;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_ii;
             break;
 
         case 1:
-            self->muladd_func_ptr = STRev_postprocessing_ai;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_ai;
             break;
 
         case 2:
-            self->muladd_func_ptr = STRev_postprocessing_revai;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_revai;
             break;
 
         case 10:
-            self->muladd_func_ptr = STRev_postprocessing_ia;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_ia;
             break;
 
         case 11:
-            self->muladd_func_ptr = STRev_postprocessing_aa;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_aa;
             break;
 
         case 12:
-            self->muladd_func_ptr = STRev_postprocessing_revaa;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_revaa;
             break;
 
         case 20:
-            self->muladd_func_ptr = STRev_postprocessing_ireva;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_ireva;
             break;
 
         case 21:
-            self->muladd_func_ptr = STRev_postprocessing_areva;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_areva;
             break;
 
         case 22:
-            self->muladd_func_ptr = STRev_postprocessing_revareva;
+            self->muladd_func_ptr = (void (*)(void *))STRev_postprocessing_revareva;
             break;
     }
 }
@@ -2067,7 +2067,7 @@ STRev_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     INIT_OBJECT_COMMON
     Stream_setFunctionPtr(self->stream, STRev_compute_next_data_frame);
-    self->mode_func_ptr = STRev_setProcMode;
+    self->mode_func_ptr = (void (*)(void *))STRev_setProcMode;
 
     static char *kwlist[] = {"mainSplitter", "chnl", "mul", "add", NULL};
 


### PR DESCRIPTION
With GCC 15, function declarations with no parameters can no longer be used for functions that take parameters.

References: https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters
Fixes: https://github.com/belangeo/pyo/issues/311
Fixes: https://github.com/belangeo/pyo/issues/288