### PR TITLE
Python 14 enablement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-04-14 nebul2 <bs@ctoic.net>
+
+    * setup.py (macOS): Replaced hardcoded Homebrew Cellar versioned paths with
+      stable opt/ symlinks (e.g. /opt/homebrew/opt/portmidi instead of
+      /opt/homebrew/Cellar/portmidi/2.0.4_1). Build now succeeds against any
+      installed version of the dependencies without requiring manual CFLAGS/LDFLAGS.
+      Verified working on Python 3.14 (macOS arm64).
+
 2025-03-20 belangeo <belangeo@gmail.com>
 
     * Added 2D table (matrix) examples in the documentation.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,10 @@
 2026-04-14 nebul2 <bs@ctoic.net>
 
-    * setup.py: Added -std=c17 to compile flags. GCC 15 (Linux) defaults to C23
-      where empty parameter lists () mean "no arguments", breaking calls to
-      function pointers declared with () but invoked with self. C17 semantics
-      restore the intended "unspecified parameters" behaviour.
+    * setup.py: Added -std=gnu17 to compile flags. GCC 15 (Linux) defaults to
+      C23 where empty parameter lists () mean "no arguments", breaking calls to
+      function pointers declared with () but invoked with self. gnu17 restores
+      the intended "unspecified parameters" behaviour while keeping GNU
+      extensions (required for M_PI and other math constants on Linux).
     * setup.py (macOS): Replaced hardcoded Homebrew Cellar versioned paths with
       stable opt/ symlinks (e.g. /opt/homebrew/opt/portmidi instead of
       /opt/homebrew/Cellar/portmidi/2.0.4_1). Build now succeeds against any

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2026-04-14 nebul2 <bs@ctoic.net>
 
+    * setup.py: Added -std=c17 to compile flags. GCC 15 (Linux) defaults to C23
+      where empty parameter lists () mean "no arguments", breaking calls to
+      function pointers declared with () but invoked with self. C17 semantics
+      restore the intended "unspecified parameters" behaviour.
     * setup.py (macOS): Replaced hardcoded Homebrew Cellar versioned paths with
       stable opt/ symlinks (e.g. /opt/homebrew/opt/portmidi instead of
       /opt/homebrew/Cellar/portmidi/2.0.4_1). Build now succeeds against any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -168,35 +168,37 @@ if sys.platform == "win32":
         libraries.append("sndfile")
 
 elif sys.platform == "darwin":
+    # package flags: (include, lib)
     pkgs_3rdpary = {
-        #package flags: (include, lib, version)
-        "flac": (False, True, "1.5.0"),
-        "liblo": (True, True, "0.32"),
-        "libogg": (False, True, "1.3.5"),
-        "libsndfile": (True, True, "1.2.2_1"),
-        "libvorbis": (False, True, "1.3.7"),
-        "opus": (False, True, "1.5.2"),
-        "portaudio": (True, True, "19.7.0"),
-        "portmidi": (True, True, "2.0.4_1"),
-        "lame": (False, True, "3.100"),
-        "mpg123": (False, True, "1.32.10"),
+        "flac": (False, True),
+        "liblo": (True, True),
+        "libogg": (False, True),
+        "libsndfile": (True, True),
+        "libvorbis": (False, True),
+        "opus": (False, True),
+        "portaudio": (True, True),
+        "portmidi": (True, True),
+        "lame": (False, True),
+        "mpg123": (False, True),
     }
 
     mac_arch = arch = platform.machine()
     if mac_arch == "arm64":
-        brew_default_root = "/opt/homebrew/Cellar"
+        brew_opt_root = "/opt/homebrew/opt"
     else:
-        brew_default_root = "/usr/local/Cellar"
-    brew_packages_root = os.environ.get("BREW_PACKAGES_ROOT", brew_default_root)
+        brew_opt_root = "/usr/local/opt"
+    brew_opt_root = os.environ.get("BREW_OPT_ROOT", brew_opt_root)
 
     include_dirs = ["include"]
     library_dirs = []
 
-    for pkg, req in pkgs_3rdpary.items():
-        pkg_dir = os.path.join(brew_packages_root, pkg, req[2])
-        if req[0]:
+    for pkg, (want_include, want_lib) in pkgs_3rdpary.items():
+        pkg_dir = os.path.join(brew_opt_root, pkg)
+        if not os.path.isdir(pkg_dir):
+            continue
+        if want_include:
             include_dirs.append(os.path.join(pkg_dir, "include"))
-        if req[1]:
+        if want_lib:
             library_dirs.append(os.path.join(pkg_dir, "lib"))
 
 else:

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ elif sys.platform == "darwin":
         data_files = (("/pyo", dylibs),)
 
 libraries += ["m"]
-extra_compile_args = ["-Wno-strict-prototypes", "-Wno-strict-aliasing", "-Wno-incompatible-pointer-types"] + oflag + gflag
+extra_compile_args = ["-std=c17", "-Wno-strict-prototypes", "-Wno-strict-aliasing", "-Wno-incompatible-pointer-types"] + oflag + gflag
 
 extensions = []
 for extension_name, extra_macros in zip(extension_names, extra_macros_per_extension):

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ elif sys.platform == "darwin":
         data_files = (("/pyo", dylibs),)
 
 libraries += ["m"]
-extra_compile_args = ["-std=c17", "-Wno-strict-prototypes", "-Wno-strict-aliasing", "-Wno-incompatible-pointer-types"] + oflag + gflag
+extra_compile_args = ["-std=gnu17", "-Wno-strict-prototypes", "-Wno-strict-aliasing", "-Wno-incompatible-pointer-types"] + oflag + gflag
 
 extensions = []
 for extension_name, extra_macros in zip(extension_names, extra_macros_per_extension):


### PR DESCRIPTION
Salut Olivier et compagnie,
Avec Matthieu, nous avons apporté quelques petites corrections (identifiées à l'aide de Claude Code) à setup.py pour que pyo compile sans problème sur les environnements récents :

1. macOS — les chemins vers les dépendances Homebrew étaient codés en dur avec les numéros de version (ex. /opt/homebrew/Cellar/portmidi/2.0.4_1). On les a remplacés par les liens symboliques stables d'Homebrew (/opt/homebrew/opt/portmidi), qui pointent toujours vers la version installée, quelle qu'elle soit. Testé et fonctionnel sur Python 3.14 (macOS arm64).
2. Linux / GCC 15 — GCC 15 adopte C23 par défaut, où une liste de paramètres vide () signifie « aucun argument », ce qui cassait les appels aux pointeurs  de fonctions internes de pyo. L'ajout de -std=gnu17 restaure le comportement attendu tout en conservant les extensions GNU nécessaires (notamment M_PI). Testé sur PC Intel Manjaro.
3. pyproject.toml — ajout de Python 3.14 dans les classifiers.

Bonne continuation et merci pour ce superbe projet !
Ben